### PR TITLE
feature: gestionar discusiones como coordinador

### DIFF
--- a/src/main/java/app/controller/AceptarDenegarArticuloController.java
+++ b/src/main/java/app/controller/AceptarDenegarArticuloController.java
@@ -11,8 +11,10 @@ import app.dto.AceptarDenegarArticuloDTO;
 import app.dto.RevisionArticuloRevisorDTO;
 import app.enums.Rol;
 import app.model.AceptarDenegarArticuloModel;
+import app.model.GestionarDiscusionesCoordinadorModel;
 import app.util.UserUtil;
 import app.view.AceptarDenegarArticuloView;
+import app.view.GestionarDiscusionesCoordinadorView;
 import giis.demo.util.SwingUtil;
 
 public class AceptarDenegarArticuloController {
@@ -74,6 +76,16 @@ public class AceptarDenegarArticuloController {
 			llenarComboBoxAutores(view.getListArticulos().getSelectedValue().getTitulo());
 
 		});
+		
+		// Listener para el botón de discusiones que va a abrir la ventana de GestionarDiscusionesCoordinadorView
+		view.getBtnAbrirDiscusiones().addActionListener(e -> {
+			// Crear el controlador de la vista de discusiones
+			GestionarDiscusionesCoordinadorController controller = new GestionarDiscusionesCoordinadorController(
+					new GestionarDiscusionesCoordinadorModel(), new GestionarDiscusionesCoordinadorView(), email);
+			// Inicializar el controlador
+			controller.initController();
+		});
+		
 
 		view.getListAutomaticos().addListSelectionListener(e -> {
 			AceptarDenegarArticuloDTO articuloSeleccionado = view.getListAutomaticos().getSelectedValue();

--- a/src/main/java/app/controller/GestionarDiscusionesCoordinadorController.java
+++ b/src/main/java/app/controller/GestionarDiscusionesCoordinadorController.java
@@ -1,0 +1,246 @@
+package app.controller;
+
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.DefaultListModel;
+import javax.swing.JOptionPane;
+import app.dto.ArticuloDiscusionDTO;
+import app.dto.RevisionArticuloRevisionDTO;
+import app.enums.Rol;
+import app.model.GestionarDiscusionesCoordinadorModel;
+import app.view.GestionarDiscusionesCoordinadorView;
+import giis.demo.util.SwingUtil;
+
+/**
+ * Controller para la gestión de discusiones a cargo del coordinador.
+ * 
+ * <p>
+ * Esta clase gestiona la interacción entre la vista y el modelo en el contexto de la 
+ * gestión de discusiones de artículos, permitiendo al coordinador:
+ * <ul>
+ *   <li>Visualizar los artículos aptos para discusión.</li>
+ *   <li>Consultar las revisiones asociadas a cada artículo.</li>
+ *   <li>Poner un artículo en discusión, notificando a los revisores correspondientes.</li>
+ * </ul>
+ * </p>
+ * 
+ * @see GestionarDiscusionesCoordinadorModel
+ * @see GestionarDiscusionesCoordinadorView
+ * @see ArticuloDiscusionDTO
+ * @see RevisionArticuloRevisionDTO
+ */
+public class GestionarDiscusionesCoordinadorController {
+
+	// Atributos de la clase
+	private GestionarDiscusionesCoordinadorModel model;
+	private GestionarDiscusionesCoordinadorView view;
+	private String email;
+	private DefaultListModel<ArticuloDiscusionDTO> listModel;
+	private List<ArticuloDiscusionDTO> articulosDTO;
+	private List<RevisionArticuloRevisionDTO> revisionesDTO;
+	private Map<Integer, List<RevisionArticuloRevisionDTO>> revisionesArticulos = new HashMap<>();
+	private static final Rol ROL = Rol.COORDINADOR;
+
+	/**
+	 * Constructor del controller.
+	 *
+	 * <p>
+	 * Inicializa el controlador con el modelo, la vista y el correo del coordinador.
+	 * Llama al backend para cargar los artículos aptos para discusión y sus revisiones asociadas,
+	 * y posteriormente inicializa la vista.
+	 * </p>
+	 *
+	 * @param m     Modelo que maneja la lógica de negocio de las discusiones.
+	 * @param v     Vista que presenta la información de los artículos y revisiones.
+	 * @param email Correo electrónico del coordinador.
+	 */
+	public GestionarDiscusionesCoordinadorController(GestionarDiscusionesCoordinadorModel m,
+			GestionarDiscusionesCoordinadorView v, String email) {
+		this.model = m;
+		this.view = v;
+		this.email = email;
+
+		// Llamar al backend para cargar los artículos aptos para discusión
+		if (!obtenerArticulos()) {
+			return;
+		}
+
+		// Llamar al backend para cargar las revisiones de los artículos cargados
+		// anteriormente
+		if (!obtenerRevisiones()) {
+			return;
+		}
+
+		// Inicializar la vista una vez que los datos están cargados.
+		this.initView();
+	}
+
+	/**
+	 * Inicializa el controller configurando los eventos de la vista.
+	 *
+	 * <p>
+	 * Se configuran los listeners para:
+	 * <ul>
+	 *   <li>Cerrar la ventana cuando se pulsa el botón "Cerrar".</li>
+	 *   <li>Mostrar las revisiones asociadas al seleccionar un artículo en la lista.</li>
+	 *   <li>Poner un artículo en discusión al pulsar el botón "Poner en Discusión".</li>
+	 * </ul>
+	 * </p>
+	 */
+	public void initController() {
+		// Botón de cerrar.
+		view.getBtnCerrar().addActionListener(e -> view.getFrame().dispose());
+
+		// Cuando se selecciona un artículo en la lista, mostrar las revisiones asociadas.
+		view.getListArticulos().addListSelectionListener(e -> {
+
+			// Obtener el DTO del artículo seleccionado.
+			ArticuloDiscusionDTO articuloSeleccionado = view.getListArticulos().getSelectedValue();
+
+			// Verifica si el objeto o su id son nulos.
+			if (articuloSeleccionado == null || articuloSeleccionado.getIdArticulo() == 0) {
+				return;
+			}
+			// Limpiar el panel de revisiones antes de agregar las nuevas.
+			view.getPanelRevisiones().removeAll();
+
+			// Mostrar la decisión final del artículo.
+			view.getLblValoracionGlobal().setText(Integer.toString(articuloSeleccionado.getValoracionGlobal()));
+
+			// Guardar las revisiones asociadas al artículo seleccionado.
+			revisionesDTO = revisionesArticulos.get(articuloSeleccionado.getIdArticulo());
+
+			String decision;
+			// Iterar sobre cada una de las revisiones del artículo seleccionado para mostrarlas.
+			for (RevisionArticuloRevisionDTO r : revisionesDTO) {
+				// Obtener la decisión del revisor usando el enum.
+				decision = app.enums.DecisionRevisor.getLabelByValue(r.getDecisionRevisor());
+				// Agregar la revisión a la vista.
+				view.addRevisionCard(r.getNombre(), r.getNivelExperto(), decision, r.getComentariosParaCoordinador());
+			}
+
+		});
+
+		// Botón de poner en discusión.
+		view.getBtnPonerEnDiscusion().addActionListener(e -> {
+			// Obtener el artículo seleccionado.
+			ArticuloDiscusionDTO articulo = view.getListArticulos().getSelectedValue();
+			if (articulo == null) {
+				SwingUtil.showMessage("No se ha seleccionado ningún artículo", "Error", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+			// Llamar al backend para poner en discusión el artículo seleccionado.
+			if (model.ponerEnDiscusion(articulo.getIdArticulo())) {
+				SwingUtil.showMessage("Artículo puesto en discusión, se ha notificado a los revisores", "Información", JOptionPane.INFORMATION_MESSAGE);
+				
+				// Eliminar del listModel el artículo puesto en discusión.
+				listModel.removeElement(articulo);
+				
+				// Limpiar los campos de texto.
+				view.getLblValoracionGlobal().setText("");
+				view.getPanelRevisiones().removeAll();
+				
+				// Comprobar si el listModel está vacío.
+				if (listModel.isEmpty()) {
+					SwingUtil.showMessage("No hay ningún artículo apto para discusión", "Información",
+							JOptionPane.INFORMATION_MESSAGE);
+					view.getFrame().dispose();
+				}
+				
+			} else {
+				SwingUtil.showMessage("No se ha podido poner en discusión el artículo", "Error",
+						JOptionPane.ERROR_MESSAGE);
+			}
+		});
+	}
+
+	/**
+	 * Inicializa la vista.
+	 *
+	 * <p>
+	 * Hace visible el frame de la vista y establece el modelo de la lista con los artículos aptos para discusión.
+	 * </p>
+	 */
+	public void initView() {
+		view.getFrame().setVisible(true);
+		// Agregar los artículos al JList.
+		view.getListArticulos().setModel(listModel);
+	}
+
+	/**
+	 * Obtiene las revisiones asociadas a los artículos aptos para discusión.
+	 *
+	 * <p>
+	 * Llama al backend para obtener la lista de revisiones y las agrupa en un mapa,
+	 * utilizando el identificador del artículo como clave. Si no se encuentran revisiones,
+	 * se muestra un mensaje informativo.
+	 * </p>
+	 *
+	 * @return <code>true</code> si se obtuvieron las revisiones correctamente; <code>false</code> en caso contrario.
+	 */
+	private boolean obtenerRevisiones() {
+		// Llamar al backend para obtener las revisiones asociadas a los artículos aptos para discusión.
+		List<RevisionArticuloRevisionDTO> revisiones = model.getRevisionesArticulos();
+
+		// Si no se han encontrado revisiones, se muestra un mensaje.
+		if (revisiones.isEmpty()) {
+			SwingUtil.showMessage("No se han encontrado revisiones", "Información", JOptionPane.INFORMATION_MESSAGE);
+			return false;
+		}
+
+		// Convertir cada elemento a DTO y almacenarlos en un mapa con el idArticulo como clave.
+		for (RevisionArticuloRevisionDTO r : revisiones) {
+			if (revisionesArticulos.containsKey(r.getIdArticulo())) {
+				revisionesArticulos.get(r.getIdArticulo()).add(r);
+			} else {
+				List<RevisionArticuloRevisionDTO> lista = new ArrayList<>();
+				lista.add(r);
+				revisionesArticulos.put(r.getIdArticulo(), lista);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Obtiene los artículos aptos para discusión.
+	 *
+	 * <p>
+	 * Llama al backend para obtener los artículos que cumplen los criterios de aptitud para discusión,
+	 * y actualiza el modelo de la lista en la vista. Si no se encuentran artículos aptos, se muestra un mensaje informativo.
+	 * </p>
+	 *
+	 * @return <code>true</code> si se obtuvieron los artículos correctamente; <code>false</code> en caso contrario.
+	 */
+	private boolean obtenerArticulos() {
+
+		// Llamar al backend para obtener los artículos aptos para discusión.
+		List<ArticuloDiscusionDTO> articulos = model.getArticulosAptosDiscusion();
+
+		// Si no hay artículos asignados, mostrar un mensaje y cerrar la vista.
+		if (articulos.isEmpty()) {
+			SwingUtil.showMessage("No hay ningún artículo apto para discusión", "Información",
+					JOptionPane.INFORMATION_MESSAGE);
+			return false;
+		}
+
+		// Convertir cada elemento a DTO y almacenarlos en una lista.
+		articulosDTO = new ArrayList<>();
+		for (ArticuloDiscusionDTO e : articulos) {
+			ArticuloDiscusionDTO dto = new ArticuloDiscusionDTO(e.getIdArticulo(), e.getTitulo(),
+					e.getValoracionGlobal());
+			articulosDTO.add(dto);
+		}
+
+		// Crear un modelo para el JList y agregar los DTOs.
+		listModel = new DefaultListModel<>();
+		for (ArticuloDiscusionDTO dto : articulosDTO) {
+			listModel.addElement(dto);
+		}
+
+		return true;
+	}
+}

--- a/src/main/java/app/dto/ArticuloDiscusionDTO.java
+++ b/src/main/java/app/dto/ArticuloDiscusionDTO.java
@@ -1,0 +1,46 @@
+package app.dto;
+
+public class ArticuloDiscusionDTO {
+	
+	private int idArticulo;
+	private String titulo;
+	private int valoracionGlobal;
+	
+	public ArticuloDiscusionDTO() {}
+	
+	public ArticuloDiscusionDTO(int idArticulo, String titulo, int valoracionGlobal) {
+		this.idArticulo = idArticulo;
+		this.titulo = titulo;
+		this.valoracionGlobal = valoracionGlobal;
+	}
+	
+	// Getters y setters
+	public int getIdArticulo() {
+		return idArticulo;
+	}
+	
+	public void setIdArticulo(int idArticulo) {
+		this.idArticulo = idArticulo;
+	}
+	
+	public String getTitulo() {
+		return titulo;
+	}
+	
+	public void setTitulo(String titulo) {
+		this.titulo = titulo;
+	}
+	
+	public int getValoracionGlobal() {
+		return valoracionGlobal;
+	}
+	
+	public void setValoracionGlobal(int valoracionGlobal) {
+		this.valoracionGlobal = valoracionGlobal;
+	}
+	
+	@Override
+	public String toString() {
+		return "Artículo" + idArticulo + ": " + titulo;
+	}
+}

--- a/src/main/java/app/dto/RevisionArticuloRevisionDTO.java
+++ b/src/main/java/app/dto/RevisionArticuloRevisionDTO.java
@@ -1,0 +1,66 @@
+package app.dto;
+
+public class RevisionArticuloRevisionDTO {
+	
+	// Atributos a mostrar en la vista
+	private int idArticulo;
+	private String nombre;
+	private String nivelExperto;
+	private int decisionRevisor;
+	private String comentariosParaCoordinador;
+	
+	// Constructor
+	public RevisionArticuloRevisionDTO() {}
+	
+	// Constructor con atributos
+	public RevisionArticuloRevisionDTO(int idArticulo, String nombre, String nivelExperto, int decisionRevisor,
+			String comentariosParaCoordinador) {
+		this.idArticulo = idArticulo;
+		this.nombre = nombre;
+		this.nivelExperto = nivelExperto;
+		this.decisionRevisor = decisionRevisor;
+		this.comentariosParaCoordinador = comentariosParaCoordinador;
+	}
+	
+	// Getters y setters
+	public int getIdArticulo() {
+		return idArticulo;
+	}
+	
+	public void setIdArticulo(int idArticulo) {
+		this.idArticulo = idArticulo;
+	}
+	
+	public String getNombre() {
+		return nombre;
+	}
+	
+	public void setNombre(String nombre) {
+		this.nombre = nombre;
+	}
+	
+	public String getNivelExperto() {
+		return nivelExperto;
+	}
+	
+	public void setNivelExperto(String nivelExperto) {
+		this.nivelExperto = nivelExperto;
+	}
+	
+	public int getDecisionRevisor() {
+		return decisionRevisor;
+	}
+	
+	public void setDecisionRevisor(int decisionRevisor) {
+		this.decisionRevisor = decisionRevisor;
+	}
+	
+	public String getComentariosParaCoordinador() {
+		return comentariosParaCoordinador;
+	}
+	
+	public void setComentariosParaCoordinador(String comentariosParaCoordinador) {
+		this.comentariosParaCoordinador = comentariosParaCoordinador;
+	}
+	
+}

--- a/src/main/java/app/model/GestionarDiscusionesCoordinadorModel.java
+++ b/src/main/java/app/model/GestionarDiscusionesCoordinadorModel.java
@@ -1,0 +1,200 @@
+package app.model;
+
+import giis.demo.util.DbUtil;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.dbutils.DbUtils;
+import org.apache.commons.dbutils.QueryRunner;
+import org.apache.commons.dbutils.handlers.MapListHandler;
+import app.dto.ArticuloDiscusionDTO;
+import app.dto.RevisionArticuloRevisionDTO;
+import giis.demo.util.Database;
+
+/**
+ * Modelo para la gestión de discusiones por parte del coordinador.
+ * 
+ * <p>
+ * Esta clase proporciona métodos para:
+ * <ul>
+ *   <li>Obtener los artículos aptos para discusión, es decir, aquellos que cumplen
+ *       criterios específicos y que aún no han sido puestos en discusión.</li>
+ *   <li>Obtener todas las revisiones asociadas a los artículos aptos para discusión.</li>
+ *   <li>Poner un artículo en discusión, lo que implica:
+ *     <ol>
+ *       <li>Insertar una entrada en la tabla <code>Discusion</code> con el <code>idArticulo</code>.</li>
+ *       <li>Recuperar el <code>idDiscusion</code> recién generado.</li>
+ *       <li>Obtener los correos de los revisores asociados al artículo (desde la tabla <code>Revision</code>).</li>
+ *       <li>Insertar entradas en la tabla <code>Usuario_Discusion</code> asociando cada revisor al <code>idDiscusion</code>.</li>
+ *     </ol>
+ *   </li>
+ * </ul>
+ * </p>
+ * 
+ * <p>
+ * Utiliza una instancia de {@link Database} para acceder a la base de datos mediante la abstracción
+ * provista por {@link DbUtil}.
+ * </p>
+ * 
+ * @see DbUtil
+ * @see Database
+ */
+public class GestionarDiscusionesCoordinadorModel {
+	
+	private Database db = new Database();
+	
+	/**
+	 * Obtiene la instancia de {@link DbUtil} utilizada para acceder a la base de datos.
+	 *
+	 * @return Instancia de {@link DbUtil} que facilita la interacción con la base de datos.
+	 */
+	public DbUtil getDbUtil() {
+		return db;
+	}
+	
+	/**
+	 * Obtiene una lista de artículos aptos para discusión.
+	 * 
+	 * <p>
+	 * Un artículo se considera apto para discusión si cumple alguno de los siguientes criterios:
+	 * <ul>
+	 *   <li><code>valoracionGlobal = 1</code>, <code>decisionRevisor = -2</code> y <code>nivelExperto</code> en ('Normal', 'Medio', 'Alto').</li>
+	 *   <li><code>valoracionGlobal = 1</code>, <code>decisionRevisor = -1</code> y <code>nivelExperto</code> en ('Medio', 'Alto').</li>
+	 *   <li><code>valoracionGlobal = 0</code>, <code>decisionRevisor = 2</code> y <code>nivelExperto = 'Alto'</code>.</li>
+	 *   <li><code>valoracionGlobal = 0</code>, <code>decisionRevisor = -1</code> y <code>nivelExperto</code> en ('Normal', 'Bajo').</li>
+	 * </ul>
+	 * Además, se excluyen aquellos artículos que ya están en discusión (presentes en la tabla <code>Discusion</code>).
+	 * </p>
+	 *
+	 * @return Lista de objetos {@link ArticuloDiscusionDTO} que representan los artículos aptos para discusión.
+	 */
+	public List<ArticuloDiscusionDTO> getArticulosAptosDiscusion() {
+	    String sql = "SELECT DISTINCT a.idArticulo AS idArticulo, "
+	        + "       a.titulo AS titulo, "
+	        + "       a.valoracionGlobal AS valoracionGlobal "
+	        + "FROM Articulo a "
+	        + "JOIN Revision r ON a.idArticulo = r.idArticulo "
+	        + "WHERE ( (a.valoracionGlobal = 1 "
+	        + "         AND r.decisionRevisor = -2 "
+	        + "         AND r.nivelExperto IN ('Normal', 'Medio', 'Alto')) "
+	        + "       OR (a.valoracionGlobal = 1 "
+	        + "           AND r.decisionRevisor = -1 "
+	        + "           AND r.nivelExperto IN ('Medio', 'Alto')) "
+	        + "       OR (a.valoracionGlobal = 0 "
+	        + "           AND r.decisionRevisor = 2 "
+	        + "           AND r.nivelExperto = 'Alto') "
+	        + "       OR (a.valoracionGlobal = 0 "
+	        + "           AND r.decisionRevisor = -1 "
+	        + "           AND r.nivelExperto IN ('Normal', 'Bajo')) ) "
+	        // Evitar artículos ya presentes en la tabla Discusion
+	        + "  AND a.idArticulo NOT IN (SELECT d.idArticulo FROM Discusion d);";
+	    
+	    return db.executeQueryPojo(ArticuloDiscusionDTO.class, sql);
+	}
+
+	/**
+	 * Obtiene una lista de todas las revisiones asociadas a los artículos aptos para discusión.
+	 * 
+	 * <p>
+	 * Se devuelven todas las revisiones de aquellos artículos que cumplen con los criterios de aptitud para discusión,
+	 * excluyendo aquellos que ya están en discusión. Los datos de cada revisión se mapean a un objeto
+	 * {@link RevisionArticuloRevisionDTO}.
+	 * </p>
+	 *
+	 * @return Lista de objetos {@link RevisionArticuloRevisionDTO} que contienen la información de las revisiones.
+	 */
+	public List<RevisionArticuloRevisionDTO> getRevisionesArticulos() {
+	    String sql = 
+	        "SELECT r.idArticulo AS idArticulo, "
+	      + "       u.nombre AS nombre, "
+	      + "       r.nivelExperto AS nivelExperto, "
+	      + "       r.decisionRevisor AS decisionRevisor, "
+	      + "       r.comentariosParaCoordinador AS comentariosParaCoordinador "
+	      + "FROM Revision r "
+	      + "JOIN Usuario u ON r.emailUsuario = u.email "
+	      + "JOIN Articulo a ON a.idArticulo = r.idArticulo "
+	      + "WHERE a.idArticulo IN ( "
+	      + "    SELECT DISTINCT a2.idArticulo "
+	      + "    FROM Articulo a2 "
+	      + "    JOIN Revision r2 ON a2.idArticulo = r2.idArticulo "
+	      + "    WHERE ( (a2.valoracionGlobal = 1 "
+	      + "             AND r2.decisionRevisor = -2 "
+	      + "             AND r2.nivelExperto IN ('Normal', 'Medio', 'Alto')) "
+	      + "           OR (a2.valoracionGlobal = 1 "
+	      + "               AND r2.decisionRevisor = -1 "
+	      + "               AND r2.nivelExperto IN ('Medio', 'Alto')) "
+	      + "           OR (a2.valoracionGlobal = 0 "
+	      + "               AND r2.decisionRevisor = 2 "
+	      + "               AND r2.nivelExperto = 'Alto') "
+	      + "           OR (a2.valoracionGlobal = 0 "
+	      + "               AND r2.decisionRevisor = -1 "
+	      + "               AND r2.nivelExperto IN ('Normal', 'Bajo')) ) "
+	      + "      AND a2.idArticulo NOT IN (SELECT d.idArticulo FROM Discusion d) "
+	      + ") "
+	      + "ORDER BY r.idArticulo"; 
+
+	    return db.executeQueryPojo(RevisionArticuloRevisionDTO.class, sql);
+	}
+	
+	/**
+	 * Pone un artículo en discusión.
+	 * 
+	 * <p>
+	 * Para poner un artículo en discusión se realiza lo siguiente:
+	 * <ol>
+	 *   <li>Se inserta una nueva entrada en la tabla <code>Discusion</code> con el <code>idArticulo</code>
+	 *       proporcionado.</li>
+	 *   <li>Se recupera el <code>idDiscusion</code> recién generado utilizando
+	 *       <code>last_insert_rowid()</code> en la misma conexión.</li>
+	 *   <li>Se obtienen los correos de todos los revisores asociados a dicho artículo desde la tabla <code>Revision</code>.</li>
+	 *   <li>Se insertan entradas en la tabla <code>Usuario_Discusion</code> para cada revisor, asociándolos al
+	 *       <code>idDiscusion</code> obtenido.</li>
+	 * </ol>
+	 * Todas estas operaciones se realizan en la misma conexión para asegurar que el método
+	 * <code>last_insert_rowid()</code> devuelva el id correcto.
+	 * </p>
+	 * 
+	 * @param idArticulo Identificador del artículo que se desea poner en discusión.
+	 * @return <code>true</code> si el artículo se puso en discusión correctamente; <code>false</code> en caso de error.
+	 */
+	public boolean ponerEnDiscusion(int idArticulo) {
+	    Connection conn = null;
+	    try {
+	        // 1) Obtenemos la conexión manualmente de la instancia db.
+	        conn = db.getConnection();
+	        QueryRunner qr = new QueryRunner();
+
+	        // 2) Insertamos el artículo en discusión en la tabla Discusion.
+	        String sqlInsertDiscusion = "INSERT INTO Discusion (idArticulo) VALUES (?)";
+	        qr.update(conn, sqlInsertDiscusion, idArticulo);
+
+	        // 3) Recuperamos el idDiscusion recién generado usando last_insert_rowid() en la misma conexión.
+	        String sqlLastId = "SELECT last_insert_rowid() AS id";
+	        List<Map<String, Object>> result = qr.query(conn, sqlLastId, new MapListHandler());
+	        if (result.isEmpty()) {
+	            // No se pudo recuperar el id generado.
+	            return false;
+	        }
+	        long idDiscusion = ((Number) result.get(0).get("id")).longValue();
+
+	        // 4) Obtenemos los correos de todos los revisores asociados a este artículo.
+	        String sqlSelectRevisores = "SELECT DISTINCT emailUsuario FROM Revision WHERE idArticulo = ?";
+	        List<Map<String, Object>> revisores = qr.query(conn, sqlSelectRevisores, new MapListHandler(), idArticulo);
+
+	        // 5) Insertamos en la tabla Usuario_Discusion cada revisor, asociándolos al idDiscusion obtenido.
+	        String sqlInsertUsuarioDiscusion = "INSERT INTO Usuario_Discusion (emailUsuario, idDiscusion) VALUES (?, ?)";
+	        for (Map<String, Object> row : revisores) {
+	            String email = (String) row.get("emailUsuario");
+	            qr.update(conn, sqlInsertUsuarioDiscusion, email, idDiscusion);
+	        }
+	        
+	        return true;
+	    } catch (Exception e) {
+	        e.printStackTrace();
+	        return false;
+	    } finally {
+	        // Cerramos la conexión.
+	        DbUtils.closeQuietly(conn);
+	    }
+	}
+}

--- a/src/main/java/app/view/AceptarDenegarArticuloView.java
+++ b/src/main/java/app/view/AceptarDenegarArticuloView.java
@@ -2,203 +2,208 @@ package app.view;
 
 import java.awt.EventQueue;
 
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JList;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.JTextPane;
+import javax.swing.JTabbedPane;
 import javax.swing.border.EmptyBorder;
 
 import app.dto.AceptarDenegarArticuloDTO;
-import app.dto.RevisionArticuloRevisorDTO;
 import net.miginfocom.swing.MigLayout;
-import javax.swing.JLabel;
 import java.awt.Font;
-import javax.swing.JTextField;
-import javax.swing.JComboBox;
-import javax.swing.JTextPane;
 import javax.swing.ListSelectionModel;
-import javax.swing.JButton;
-import javax.swing.JList;
-import java.awt.event.ActionListener;
-import java.awt.event.ActionEvent;
-import javax.swing.DefaultComboBoxModel;
-import java.awt.event.ItemListener;
-import java.awt.event.ItemEvent;
-import javax.swing.JTabbedPane;
 
 public class AceptarDenegarArticuloView {
 
-	private JPanel contentPane;
-	private JTextField tfNivelDeExperto;
-	private JTextField tfDecision;
-	private JComboBox cbRevisor;
-	private JLabel lbComentariosParaAutores;
-	private JLabel lbComentariosCoordinadores;
-	private JTextPane tpComentariosParaAutores;
-	private JTextPane tpComentariosParaCoordinadores;
-	private JLabel lbValoraciónGlobal;
-	private JTextField tfValoracionGlobal;
-	private JButton btnAceptar;
-	private JButton btnRechazar;
-	private JLabel lbArticulosSinDecisionRegistrada;
-	private JList<AceptarDenegarArticuloDTO> lstArticulosSinDecisionRegistrada;
+    private JPanel contentPane;
+    private JTextField tfNivelDeExperto;
+    private JTextField tfDecision;
+    private JComboBox cbRevisor;
+    private JLabel lbComentariosParaAutores;
+    private JLabel lbComentariosCoordinadores;
+    private JTextPane tpComentariosParaAutores;
+    private JTextPane tpComentariosParaCoordinadores;
+    private JLabel lbValoraciónGlobal;
+    private JTextField tfValoracionGlobal;
+    private JButton btnAceptar;
+    private JButton btnRechazar;
+    private JLabel lbArticulosSinDecisionRegistrada;
+    private JList<AceptarDenegarArticuloDTO> lstArticulosSinDecisionRegistrada;
 
-	private JFrame frame;
-	private JTabbedPane tpListas;
-	private JList<AceptarDenegarArticuloDTO> lstAutomaticos;
-	private JButton btnAceptarTodos;
+    private JFrame frame;
+    private JTabbedPane tpListas;
+    private JList<AceptarDenegarArticuloDTO> lstAutomaticos;
+    private JButton btnAceptarTodos;
 
-	public AceptarDenegarArticuloView() {
-		initialize();
-	}
+    // --- NUEVO: botón para abrir discusiones ---
+    private JButton btnAbrirDiscusiones;
 
+    public AceptarDenegarArticuloView() {
+        initialize();
+    }
 
-	public void initialize() {
-		frame = new JFrame();
-		frame.setBounds(100, 100, 450, 300);
-		frame.getContentPane().setLayout(null);
-		frame.setTitle("Aceptar o denegar artículos");
-		frame.setBounds(100, 100, 757, 533);
-		contentPane = new JPanel();
-		contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
+    public void initialize() {
+        frame = new JFrame();
+        frame.setBounds(100, 100, 450, 300);
+        frame.getContentPane().setLayout(null);
+        frame.setTitle("Aceptar o denegar artículos");
+        frame.setBounds(100, 100, 757, 533);
+        contentPane = new JPanel();
+        contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
 
-		frame.setContentPane(contentPane);
-		contentPane.setLayout(new MigLayout("", "[][grow][][][grow][][][][][215.00,grow][][grow]", "[][][::25px,grow][][][][][][grow][][grow][][][]"));
+        frame.setContentPane(contentPane);
+        contentPane.setLayout(new MigLayout("", "[][grow][][][grow][][][][][215.00,grow][][grow]", "[][][::25px,grow][][][][][][grow][][grow][][][]"));
 
-		lbArticulosSinDecisionRegistrada = new JLabel("Artículos sin decisión registrada");
-		lbArticulosSinDecisionRegistrada.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		contentPane.add(lbArticulosSinDecisionRegistrada, "cell 1 1 7 1");
+        lbArticulosSinDecisionRegistrada = new JLabel("Artículos sin decisión registrada");
+        lbArticulosSinDecisionRegistrada.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(lbArticulosSinDecisionRegistrada, "cell 1 1 7 1");
 
-		JLabel lbRevisor = new JLabel("Revisor");
-		lbRevisor.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		contentPane.add(lbRevisor, "cell 9 1,alignx left");
+        JLabel lbRevisor = new JLabel("Revisor");
+        lbRevisor.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(lbRevisor, "cell 9 1,alignx left");
 
-		cbRevisor = new JComboBox();
+        cbRevisor = new JComboBox();
+        cbRevisor.setModel(new DefaultComboBoxModel(new String[] { "Revisor 1", "Revisor 2", "Revisor 3" }));
+        cbRevisor.setSelectedIndex(0);
+        contentPane.add(cbRevisor, "cell 10 1,growx");
 
-		cbRevisor.setModel(new DefaultComboBoxModel(new String[] { "Revisor 1", "Revisor 2", "Revisor 3" }));
-		cbRevisor.setSelectedIndex(0);
-		contentPane.add(cbRevisor, "cell 10 1,growx");
+        JLabel lbNivelDeExperto = new JLabel("Nivel de experto");
+        lbNivelDeExperto.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(lbNivelDeExperto, "cell 9 3");
 
-		JLabel lbNivelDeExperto = new JLabel("Nivel de experto");
-		lbNivelDeExperto.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		contentPane.add(lbNivelDeExperto, "cell 9 3");
+        tfNivelDeExperto = new JTextField();
+        tfNivelDeExperto.setEditable(false);
+        contentPane.add(tfNivelDeExperto, "cell 10 3,growx");
+        tfNivelDeExperto.setColumns(10);
 
-		tfNivelDeExperto = new JTextField();
-		tfNivelDeExperto.setEditable(false);
-		contentPane.add(tfNivelDeExperto, "cell 10 3,growx");
-		tfNivelDeExperto.setColumns(10);
+        JLabel lblDecisión = new JLabel("Decisión");
+        lblDecisión.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(lblDecisión, "cell 9 5");
 
-		JLabel lblDecisión = new JLabel("Decisión");
-		lblDecisión.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		contentPane.add(lblDecisión, "cell 9 5");
+        tfDecision = new JTextField();
+        tfDecision.setEditable(false);
+        contentPane.add(tfDecision, "cell 10 5,growx");
+        tfDecision.setColumns(10);
 
-		tfDecision = new JTextField();
-		tfDecision.setEditable(false);
-		contentPane.add(tfDecision, "cell 10 5,growx");
-		tfDecision.setColumns(10);
+        lbComentariosParaAutores = new JLabel("Comentarios para los autores");
+        lbComentariosParaAutores.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(lbComentariosParaAutores, "cell 9 7");
 
-		lbComentariosParaAutores = new JLabel("Comentarios para los autores");
-		lbComentariosParaAutores.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		contentPane.add(lbComentariosParaAutores, "cell 9 7");
+        tpComentariosParaAutores = new JTextPane();
+        tpComentariosParaAutores.setEditable(false);
+        contentPane.add(tpComentariosParaAutores, "cell 9 8 3 1,grow");
 
-		tpComentariosParaAutores = new JTextPane();
-		tpComentariosParaAutores.setEditable(false);
-		contentPane.add(tpComentariosParaAutores, "cell 9 8 3 1,grow");
+        lbComentariosCoordinadores = new JLabel("Comentarios para los coordinadores");
+        lbComentariosCoordinadores.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(lbComentariosCoordinadores, "cell 9 9");
 
-		lbComentariosCoordinadores = new JLabel("Comentarios para los coordinadores");
-		lbComentariosCoordinadores.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		contentPane.add(lbComentariosCoordinadores, "cell 9 9");
-		
-		tpListas = new JTabbedPane(JTabbedPane.TOP);
-		tpListas.setFont(new Font("Tahoma", Font.PLAIN, 11));
+        tpListas = new JTabbedPane(JTabbedPane.TOP);
+        tpListas.setFont(new Font("Tahoma", Font.PLAIN, 11));
+        contentPane.add(tpListas, "cell 1 2 7 9,grow");
 
-		contentPane.add(tpListas, "cell 1 2 7 9,grow");
-		
-				//Lista
-				lstArticulosSinDecisionRegistrada = new JList<>();
-				tpListas.addTab("Sin registro", null, lstArticulosSinDecisionRegistrada, null);
-				lstArticulosSinDecisionRegistrada.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-				
-				lstAutomaticos = new JList();
-				tpListas.addTab("Automáticos", null, lstAutomaticos, null);
+        //Lista
+        lstArticulosSinDecisionRegistrada = new JList<>();
+        tpListas.addTab("Sin registro", null, lstArticulosSinDecisionRegistrada, null);
+        lstArticulosSinDecisionRegistrada.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
-		tpComentariosParaCoordinadores = new JTextPane();
-		tpComentariosParaCoordinadores.setEditable(false);
-		contentPane.add(tpComentariosParaCoordinadores, "cell 9 10 3 1,grow");
-		
-		btnAceptarTodos = new JButton("Aceptar todos");
-		btnAceptarTodos.setEnabled(false);
-		btnAceptarTodos.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		contentPane.add(btnAceptarTodos, "cell 1 11 4 1");
+        lstAutomaticos = new JList();
+        tpListas.addTab("Automáticos", null, lstAutomaticos, null);
 
-		lbValoraciónGlobal = new JLabel("Valoración global");
-		lbValoraciónGlobal.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		contentPane.add(lbValoraciónGlobal, "cell 9 11,alignx left,aligny baseline");
+        tpComentariosParaCoordinadores = new JTextPane();
+        tpComentariosParaCoordinadores.setEditable(false);
+        contentPane.add(tpComentariosParaCoordinadores, "cell 9 10 3 1,grow");
 
-		tfValoracionGlobal = new JTextField();
-		tfValoracionGlobal.setEditable(false);
-		tfValoracionGlobal.setColumns(10);
-		contentPane.add(tfValoracionGlobal, "cell 10 11,growx");
+        btnAceptarTodos = new JButton("Aceptar todos");
+        btnAceptarTodos.setEnabled(false);
+        btnAceptarTodos.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(btnAceptarTodos, "cell 1 11 4 1");
 
-		btnAceptar = new JButton("Aceptar");
-		btnAceptar.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		contentPane.add(btnAceptar, "cell 10 13");
+        lbValoraciónGlobal = new JLabel("Valoración global");
+        lbValoraciónGlobal.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(lbValoraciónGlobal, "cell 9 11,alignx left,aligny baseline");
 
-		btnRechazar = new JButton("Rechazar");
-		btnRechazar.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		contentPane.add(btnRechazar, "cell 11 13");
-	}
+        tfValoracionGlobal = new JTextField();
+        tfValoracionGlobal.setEditable(false);
+        tfValoracionGlobal.setColumns(10);
+        contentPane.add(tfValoracionGlobal, "cell 10 11,growx");
 
-	// Getters
+        btnAceptar = new JButton("Aceptar");
+        btnAceptar.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(btnAceptar, "cell 10 13");
 
-	public JFrame getFrame() {
-		return this.frame;
-	}
-	
-	public JList<AceptarDenegarArticuloDTO> getListArticulos() {
-		return this.lstArticulosSinDecisionRegistrada;
-	}
+        btnRechazar = new JButton("Rechazar");
+        btnRechazar.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(btnRechazar, "cell 11 13");
 
-	public JList<AceptarDenegarArticuloDTO> getListAutomaticos() {
-		return this.lstAutomaticos;
-	}
-	
-	public JButton getbtnAceptar() {
-		return this.btnAceptar;
-	}
-	
-	public JButton getbtnRechazar() {
-		return this.btnRechazar;
-	}
+        btnAbrirDiscusiones = new JButton("Gestionar Discusiones");
+        btnAbrirDiscusiones.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        contentPane.add(btnAbrirDiscusiones, "cell 9 13");
 
-	public JComboBox getcbRevisor() {
-		return this.cbRevisor;
-	}
+    }
 
-	public JTextField gettfNivelDeExperto() {
-		return this.tfNivelDeExperto;
-	}
-	
-	public JTextPane gettpComentariosParaAutores() {
-		return this.tpComentariosParaAutores;
-	}
-	
-	public JTextPane gettpComentariosParaCoordinadores() {
-		return this.tpComentariosParaCoordinadores;
-	}
-	
-	public JTextField gettfDecision() {
-		return this.tfDecision;
-	}
-	
-	public JTextField gettfValoracion() {
-		return this.tfValoracionGlobal;
-	}
-	
-	public JButton getbtnAceptarTodos() {
-		return this.btnAceptarTodos;
-	}
+    // Getters
 
-	public JTabbedPane gettpListas() {
-		return this.tpListas;
-	}
-	
+    public JFrame getFrame() {
+        return this.frame;
+    }
+
+    public JList<AceptarDenegarArticuloDTO> getListArticulos() {
+        return this.lstArticulosSinDecisionRegistrada;
+    }
+
+    public JList<AceptarDenegarArticuloDTO> getListAutomaticos() {
+        return this.lstAutomaticos;
+    }
+
+    public JButton getbtnAceptar() {
+        return this.btnAceptar;
+    }
+
+    public JButton getbtnRechazar() {
+        return this.btnRechazar;
+    }
+
+    public JComboBox getcbRevisor() {
+        return this.cbRevisor;
+    }
+
+    public JTextField gettfNivelDeExperto() {
+        return this.tfNivelDeExperto;
+    }
+
+    public JTextPane gettpComentariosParaAutores() {
+        return this.tpComentariosParaAutores;
+    }
+
+    public JTextPane gettpComentariosParaCoordinadores() {
+        return this.tpComentariosParaCoordinadores;
+    }
+
+    public JTextField gettfDecision() {
+        return this.tfDecision;
+    }
+
+    public JTextField gettfValoracion() {
+        return this.tfValoracionGlobal;
+    }
+
+    public JButton getbtnAceptarTodos() {
+        return this.btnAceptarTodos;
+    }
+
+    public JTabbedPane gettpListas() {
+        return this.tpListas;
+    }
+
+    // NUEVO getter para el botón de discusiones
+    public JButton getBtnAbrirDiscusiones() {
+        return this.btnAbrirDiscusiones;
+    }
+
 }

--- a/src/main/java/app/view/GestionarDiscusionesCoordinadorView.java
+++ b/src/main/java/app/view/GestionarDiscusionesCoordinadorView.java
@@ -1,0 +1,258 @@
+package app.view;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSeparator;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.LineBorder;
+
+import app.dto.ArticuloDiscusionDTO;
+import app.enums.DecisionRevisor;
+
+import javax.swing.BorderFactory;
+
+public class GestionarDiscusionesCoordinadorView {
+	
+	// -----------------------------------------------------
+	// Atributos de la vista
+	// -----------------------------------------------------
+	private JFrame frame;                       // Marco principal
+
+	// Panel contenedor principal
+	private JPanel contentPane;
+
+	// Lista de artículos controversiales
+	private JList<ArticuloDiscusionDTO> listArticulos;
+
+	// Etiqueta para mostrar la valoración global
+	private JLabel lblValoracionGlobal;
+
+	// Panel que contendrá las "tarjetas" de revisiones conflictivas
+	private JPanel panelRevisiones;
+	private JScrollPane scrollRevisiones;
+
+	// Botones
+	private JButton btnPonerEnDiscusion;
+	private JButton btnCerrar;
+
+	// -----------------------------------------------------
+	// Constructor
+	// -----------------------------------------------------
+	public GestionarDiscusionesCoordinadorView() {
+		initialize();
+	}
+
+	// -----------------------------------------------------
+	// Inicializar la interfaz gráfica
+	// -----------------------------------------------------
+	private void initialize() {
+		frame = new JFrame();
+		frame.setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
+		frame.setTitle("Gestión de Discusiones de Artículos");
+		frame.setBounds(100, 100, 900, 500);
+
+		contentPane = new JPanel();
+		contentPane.setBorder(new EmptyBorder(10, 10, 10, 10));
+		contentPane.setLayout(new BorderLayout(10, 10));
+		frame.setContentPane(contentPane);
+
+		// -----------------------------------------------------
+		// Panel Izquierdo: Lista de artículos
+		// -----------------------------------------------------
+		JPanel panelArticulos = new JPanel(new BorderLayout());
+		panelArticulos.setBorder(BorderFactory.createTitledBorder("Artículos aptos para discusión"));
+
+		listArticulos = new JList<>();
+		listArticulos.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+
+		JScrollPane scrollArticulos = new JScrollPane(listArticulos);
+		panelArticulos.add(scrollArticulos, BorderLayout.CENTER);
+		panelArticulos.setPreferredSize(new Dimension(250, 0));
+
+		contentPane.add(panelArticulos, BorderLayout.WEST);
+
+		// -----------------------------------------------------
+		// Panel Derecho: Detalles del artículo
+		// -----------------------------------------------------
+		JPanel panelDerecho = new JPanel(new BorderLayout(10, 10));
+		contentPane.add(panelDerecho, BorderLayout.CENTER);
+
+		// Panel superior: valoración global
+		JPanel panelSuperior = new JPanel(new FlowLayout(FlowLayout.CENTER));
+		panelSuperior.setBorder(BorderFactory.createTitledBorder("Valoración Global"));
+
+		lblValoracionGlobal = new JLabel("");
+		lblValoracionGlobal.setFont(new Font("SansSerif", Font.BOLD, 16));
+		lblValoracionGlobal.setHorizontalAlignment(SwingConstants.CENTER);
+
+		panelSuperior.add(lblValoracionGlobal);
+		panelDerecho.add(panelSuperior, BorderLayout.NORTH);
+
+		// Panel central: revisiones conflictivas
+		panelRevisiones = new JPanel();
+		panelRevisiones.setLayout(new BoxLayout(panelRevisiones, BoxLayout.Y_AXIS));
+
+		scrollRevisiones = new JScrollPane(panelRevisiones);
+		scrollRevisiones.setBorder(BorderFactory.createTitledBorder("Revisiones conflictivas"));
+		scrollRevisiones.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+		scrollRevisiones.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+
+		panelDerecho.add(scrollRevisiones, BorderLayout.CENTER);
+
+		// Panel inferior: botones
+		JPanel panelInferior = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+		btnPonerEnDiscusion = new JButton("Poner en Discusión");
+		panelInferior.add(btnPonerEnDiscusion);
+
+		btnCerrar = new JButton("Cerrar");
+		panelInferior.add(btnCerrar);
+
+		panelDerecho.add(panelInferior, BorderLayout.SOUTH);
+
+		// Seleccionar el primer artículo por defecto (ejemplo)
+		if (listArticulos.getModel().getSize() > 0) {
+			listArticulos.setSelectedIndex(0);
+		}
+	}
+
+	// -----------------------------------------------------
+	// Métodos de la "lógica de UI" que el controlador puede invocar
+	// -----------------------------------------------------
+
+	/**
+	 * Muestra la ventana principal
+	 */
+	public void showWindow() {
+		this.frame.setVisible(true);
+	}
+
+	/**
+	 * Oculta o cierra la ventana
+	 */
+	public void hideWindow() {
+		this.frame.setVisible(false);
+	}
+
+	/**
+	 * Limpia el panel de revisiones
+	 */
+	public void clearRevisiones() {
+		panelRevisiones.removeAll();
+		panelRevisiones.revalidate();
+		scrollRevisiones.getVerticalScrollBar().setValue(0);
+	}
+
+	/**
+	 * Agrega una "tarjeta" de revisión al panel de revisiones.
+	 * NOTA: Se eliminó la lógica de colorear la decisión.
+	 */
+	public void addRevisionCard(String revisor, String nivel, String decision, String comentario) {
+	    JPanel tarjetaRevision = new JPanel(new BorderLayout(5, 5));
+	    tarjetaRevision.setBorder(BorderFactory.createCompoundBorder(
+	        new EmptyBorder(5, 5, 5, 5),
+	        BorderFactory.createCompoundBorder(
+	            new LineBorder(new Color(200, 200, 200), 1, true),
+	            new EmptyBorder(10, 10, 10, 10)
+	        )
+	    ));
+	    tarjetaRevision.setMaximumSize(new Dimension(Integer.MAX_VALUE, 200));
+	    tarjetaRevision.setBackground(new Color(250, 250, 250));
+
+	    // 1. Obtenemos la instancia de DecisionRevisor a partir de la etiqueta 'decision'
+	    DecisionRevisor decisionRevisor = DecisionRevisor.fromLabel(decision);
+	    
+	    // Construimos el encabezado HTML
+	    String encabezadoHtml = String.format("<html><body>"
+	        + "<b>%s</b> | <b>Nivel %s</b> | <b>%s</b>"
+	        + "</body></html>", revisor, nivel, decision);
+
+	    JLabel lblEncabezado = new JLabel(encabezadoHtml);
+	    lblEncabezado.setFont(new Font("SansSerif", Font.PLAIN, 12));
+
+	    // 2. Si el enum existe, aplicamos su color al label de encabezado
+	    if (decisionRevisor != null) {
+	        lblEncabezado.setForeground(decisionRevisor.getColor());
+	    }
+
+	    JPanel panelEncabezado = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 5));
+	    panelEncabezado.setOpaque(false);
+	    panelEncabezado.add(lblEncabezado);
+
+	    tarjetaRevision.add(panelEncabezado, BorderLayout.NORTH);
+
+	    JSeparator separador = new JSeparator();
+	    separador.setForeground(new Color(220, 220, 220));
+	    tarjetaRevision.add(separador, BorderLayout.CENTER);
+
+	    JPanel panelComentario = new JPanel(new BorderLayout(5, 5));
+	    panelComentario.setOpaque(false);
+
+	    JLabel lblComentarioTitulo = new JLabel("Comentario:");
+	    lblComentarioTitulo.setFont(new Font("SansSerif", Font.BOLD, 12));
+
+	    JLabel lblComentarioValor = new JLabel("<html><p style='width:400px'>" + comentario + "</p></html>");
+
+	    panelComentario.add(lblComentarioTitulo, BorderLayout.NORTH);
+	    panelComentario.add(lblComentarioValor, BorderLayout.CENTER);
+
+	    tarjetaRevision.add(panelComentario, BorderLayout.SOUTH);
+
+	    panelRevisiones.add(tarjetaRevision);
+	    panelRevisiones.add(Box.createRigidArea(new Dimension(0, 10)));
+
+	    panelRevisiones.revalidate();
+	    scrollRevisiones.getVerticalScrollBar().setValue(0);
+	}
+
+
+	// -----------------------------------------------------
+	// Getters y Setters para que el controlador acceda a los componentes
+	// -----------------------------------------------------
+
+	public JFrame getFrame() {
+		return frame;
+	}
+
+	public JPanel getContentPane() {
+		return contentPane;
+	}
+
+	public JList<ArticuloDiscusionDTO> getListArticulos() {
+		return listArticulos;
+	}
+
+	public JLabel getLblValoracionGlobal() {
+		return lblValoracionGlobal;
+	}
+
+	public JPanel getPanelRevisiones() {
+		return panelRevisiones;
+	}
+
+	public JScrollPane getScrollRevisiones() {
+		return scrollRevisiones;
+	}
+
+	public JButton getBtnPonerEnDiscusion() {
+		return btnPonerEnDiscusion;
+	}
+
+	public JButton getBtnCerrar() {
+		return btnCerrar;
+	}
+
+}

--- a/src/main/resources/dataConferencias.sql
+++ b/src/main/resources/dataConferencias.sql
@@ -229,6 +229,3 @@ VALUES
 ('maria.lopez@ejemplo.com', 10),
 ('paquin@ejemplo.com', 11),
 ('carlos.sanchez@ejemplo.com', 12);
-
-
-


### PR DESCRIPTION
Funcionalidad terminada para la siguiente historia de usuario:

**Titulo**: Como coordinador, quiero gestionar discusiones para artículos controvertidos
**Descripción**: El coordinador visualiza una lista con los artículos que son aptos para entrar en discusión:
1. Valoración global = 1, y se ha emitido un rechazo fuerte por parte de un revisor con nivel normal, medio o alto; o un rechazo débil por parte de un revisor con nivel medio o alto.
2. Valoración global = 0, y existe una aceptación fuerte de un revisor con nivel alto o un rechazo débil de un revisor con nivel normal o bajo.
- Cuando se pone el artículo en discusión, se notifica a todos los revisores del artículo que el artículo se encuentra en discusión y que deben de entrar a revisarlo nuevamente.