### PR TITLE
feature: Rechazar artículos automáticamente

### DIFF
--- a/src/main/java/app/controller/AceptarDenegarArticuloController.java
+++ b/src/main/java/app/controller/AceptarDenegarArticuloController.java
@@ -33,6 +33,7 @@ public class AceptarDenegarArticuloController {
 	private int valoracionFinal;
 	DefaultListModel<AceptarDenegarArticuloDTO> listModel;
 	DefaultListModel<AceptarDenegarArticuloDTO> listModelAuto;
+	DefaultListModel<AceptarDenegarArticuloDTO> listModelAutoDenegar;
 	DefaultListModel<AceptarDenegarArticuloDTO> listModelCambios;
 
 	private static final Rol ROL = Rol.COORDINADOR;
@@ -60,6 +61,10 @@ public class AceptarDenegarArticuloController {
 			return;
 		}
 
+		if (!obtenerArticulosAutomaticosDenegar()) {
+			return;
+		}
+
 		// Inicializar la vista una vez que los datos están cargados.
 		this.initView();
 	}
@@ -78,6 +83,12 @@ public class AceptarDenegarArticuloController {
 			view.gettpListas().setEnabledAt(2, true);
 		}
 
+		if (view.getListAutomaticosDenegar().getModel().getSize() == 0) {
+			view.gettpListas().setEnabledAt(3, false);
+		} else {
+			view.gettpListas().setEnabledAt(3, true);
+		}
+
 		view.getcbRevisor().removeAllItems();
 
 		view.getListArticulos().addListSelectionListener(e -> {
@@ -92,8 +103,9 @@ public class AceptarDenegarArticuloController {
 			llenarComboBoxAutores(view.getListArticulos().getSelectedValue().getTitulo());
 
 		});
-		
-		// Listener para el botón de discusiones que va a abrir la ventana de GestionarDiscusionesCoordinadorView
+
+		// Listener para el botón de discusiones que va a abrir la ventana de
+		// GestionarDiscusionesCoordinadorView
 		view.getBtnAbrirDiscusiones().addActionListener(e -> {
 			// Crear el controlador de la vista de discusiones
 			GestionarDiscusionesCoordinadorController controller = new GestionarDiscusionesCoordinadorController(
@@ -101,7 +113,6 @@ public class AceptarDenegarArticuloController {
 			// Inicializar el controlador
 			controller.initController();
 		});
-		
 
 		view.getListAutomaticos().addListSelectionListener(e -> {
 			AceptarDenegarArticuloDTO articuloSeleccionado = view.getListAutomaticos().getSelectedValue();
@@ -113,6 +124,19 @@ public class AceptarDenegarArticuloController {
 			// Guarda el id en una variable (objeto Integer)
 			Integer idSeleccionado = articuloSeleccionado.getId();
 			llenarComboBoxAutores(view.getListAutomaticos().getSelectedValue().getTitulo());
+
+		});
+
+		view.getListAutomaticosDenegar().addListSelectionListener(e -> {
+			AceptarDenegarArticuloDTO articuloSeleccionado = view.getListAutomaticosDenegar().getSelectedValue();
+			// Verifica si el objeto o su id son nulos
+			if (articuloSeleccionado == null || articuloSeleccionado.getId() == 0) {
+				return;
+			}
+
+			// Guarda el id en una variable (objeto Integer)
+			Integer idSeleccionado = articuloSeleccionado.getId();
+			llenarComboBoxAutores(view.getListAutomaticosDenegar().getSelectedValue().getTitulo());
 
 		});
 
@@ -137,7 +161,8 @@ public class AceptarDenegarArticuloController {
 		view.getbtnAceptar().addActionListener(e -> {
 			// Si no se ha seleccionado nada en ninguna lista salta un error
 			if (view.getListArticulos().getSelectedValue() == null
-					&& view.getListAutomaticos().getSelectedValue() == null) {
+					&& view.getListAutomaticos().getSelectedValue() == null
+					&& view.getListAutomaticosDenegar().getSelectedValue() == null) {
 				JOptionPane.showMessageDialog(null, "No hay ningún artículo seleccionado", "Error",
 						JOptionPane.ERROR_MESSAGE);
 			} else {
@@ -163,6 +188,14 @@ public class AceptarDenegarArticuloController {
 						}
 					}
 
+					for (int i = 0; i < view.getListAutomaticosDenegar().getModel().getSize(); i++) {
+						if (view.getListArticulos().getSelectedValue().getTitulo()
+								.equals(view.getListAutomaticosDenegar().getModel().getElementAt(i).getTitulo())) {
+							listModelAutoDenegar
+									.removeElement(view.getListAutomaticosDenegar().getModel().getElementAt(i));
+						}
+					}
+
 					listModel.removeElement(view.getListArticulos().getSelectedValue());
 					// Si está vacía se cierra la pantalla
 					if (listModel.isEmpty()) {
@@ -177,6 +210,11 @@ public class AceptarDenegarArticuloController {
 					} else {
 						view.getListArticulos().setSelectedIndex(0);
 					}
+					if (view.getListAutomaticos().getModel().getSize() == 0) {
+						view.gettpListas().setEnabledAt(1, false);
+						view.gettpListas().setSelectedIndex(0);
+					}
+
 					// Si el artículo seleccionado pertenece a la segunda lista
 				} else if (view.gettpListas().getSelectedIndex() == 1) {
 					int indice = view.getListAutomaticos().getSelectedIndex();
@@ -193,9 +231,17 @@ public class AceptarDenegarArticuloController {
 					}
 
 					for (int i = 0; i < view.getListAceptarConCambios().getModel().getSize(); i++) {
-						if (view.getListArticulos().getSelectedValue().getTitulo()
+						if (view.getListAutomaticos().getSelectedValue().getTitulo()
 								.equals(view.getListAceptarConCambios().getModel().getElementAt(i).getTitulo())) {
 							listModelCambios.removeElement(view.getListAceptarConCambios().getModel().getElementAt(i));
+						}
+					}
+
+					for (int i = 0; i < view.getListAutomaticosDenegar().getModel().getSize(); i++) {
+						if (view.getListAutomaticos().getSelectedValue().getTitulo()
+								.equals(view.getListAutomaticosDenegar().getModel().getElementAt(i).getTitulo())) {
+							listModelAutoDenegar
+									.removeElement(view.getListAutomaticosDenegar().getModel().getElementAt(i));
 						}
 					}
 
@@ -213,15 +259,59 @@ public class AceptarDenegarArticuloController {
 					} else {
 						view.getListAutomaticos().setSelectedIndex(0);
 					}
+					if (view.getListAutomaticos().getModel().getSize() == 0) {
+						view.gettpListas().setEnabledAt(1, false);
+						view.gettpListas().setSelectedIndex(0);
+					}
+				} else if (view.gettpListas().getSelectedIndex() == 3) {
+					int indice = view.getListAutomaticosDenegar().getSelectedIndex();
+					model.actualizarDecisionFinal("Aceptado",
+							view.getListAutomaticosDenegar().getSelectedValue().getTitulo());
+					SwingUtil.showMessage("Artículo aceptado correctamente", "Información",
+							JOptionPane.INFORMATION_MESSAGE);
+					// Si el artículo está en la otra lista, lo elimina también
+					for (int i = 0; i < view.getListArticulos().getModel().getSize(); i++) {
+
+						if (view.getListAutomaticosDenegar().getSelectedValue().getTitulo()
+								.equals(view.getListArticulos().getModel().getElementAt(i).getTitulo())) {
+							listModel.removeElement(view.getListArticulos().getModel().getElementAt(i));
+						}
+					}
+
+					for (int i = 0; i < view.getListAceptarConCambios().getModel().getSize(); i++) {
+						if (view.getListAutomaticosDenegar().getSelectedValue().getTitulo()
+								.equals(view.getListAceptarConCambios().getModel().getElementAt(i).getTitulo())) {
+							listModelCambios.removeElement(view.getListAceptarConCambios().getModel().getElementAt(i));
+						}
+					}
+
+					for (int i = 0; i < view.getListAutomaticos().getModel().getSize(); i++) {
+						if (view.getListAutomaticosDenegar().getSelectedValue().getTitulo()
+								.equals(view.getListAutomaticos().getModel().getElementAt(i).getTitulo())) {
+							listModelAuto.removeElement(view.getListAutomaticos().getModel().getElementAt(i));
+						}
+					}
+
+					listModelAutoDenegar.removeElement(view.getListAutomaticosDenegar().getSelectedValue());
+					// Si no hay elementos en las listas, se cierra la ventana
+					if (listModelAuto.isEmpty() && listModel.isEmpty() && listModelAutoDenegar.isEmpty()) {
+						SwingUtil.showMessage("No tienes ningún artículo pendiente de registrar", "Información",
+								JOptionPane.INFORMATION_MESSAGE);
+						view.getFrame().dispose();
+					}
+					// Cuando se elimina un elemento se va seleccionando el elemento anterior
+					// excepto si el índice es 0
+					if (indice != 0) {
+						view.getListAutomaticosDenegar().setSelectedIndex(indice - 1);
+					} else {
+						view.getListAutomaticosDenegar().setSelectedIndex(0);
+					}
+					if (view.getListAutomaticosDenegar().getModel().getSize() == 0) {
+						view.gettpListas().setEnabledAt(3, false);
+						view.gettpListas().setSelectedIndex(0);
+					}
 				}
 
-			}
-
-			if (view.getListAutomaticos().getModel().getSize() == 0) {
-				view.gettpListas().setEnabledAt(1, false);
-			}
-			if (view.getListAceptarConCambios().getModel().getSize() == 0) {
-				view.gettpListas().setEnabledAt(2, false);
 			}
 
 		});
@@ -232,7 +322,8 @@ public class AceptarDenegarArticuloController {
 			// Si el artículo seleccionado pertenece a la primera lista
 
 			int indice = view.getListAceptarConCambios().getSelectedIndex();
-			model.actualizarDecisionFinal("Aceptado con cambios", view.getListAceptarConCambios().getSelectedValue().getTitulo());
+			model.actualizarDecisionFinal("Aceptado con cambios",
+					view.getListAceptarConCambios().getSelectedValue().getTitulo());
 			SwingUtil.showMessage("Artículo aceptado correctamente", "Información", JOptionPane.INFORMATION_MESSAGE);
 			// Elimina el artículo de las dos listas
 			for (int i = 0; i < view.getListArticulos().getModel().getSize(); i++) {
@@ -248,6 +339,14 @@ public class AceptarDenegarArticuloController {
 				if (view.getListAceptarConCambios().getSelectedValue().getTitulo()
 						.equals(view.getListAutomaticos().getModel().getElementAt(i).getTitulo())) {
 					listModelAuto.removeElement(view.getListAutomaticos().getModel().getElementAt(i));
+				}
+			}
+
+			for (int i = 0; i < view.getListAutomaticosDenegar().getModel().getSize(); i++) {
+
+				if (view.getListAceptarConCambios().getSelectedValue().getTitulo()
+						.equals(view.getListAutomaticosDenegar().getModel().getElementAt(i).getTitulo())) {
+					listModelAutoDenegar.removeElement(view.getListAutomaticosDenegar().getModel().getElementAt(i));
 				}
 			}
 
@@ -279,7 +378,8 @@ public class AceptarDenegarArticuloController {
 			// Si no se ha seleccionado nada en ninguna lista salta un error
 			if (view.getListArticulos().getSelectedValue() == null
 					&& view.getListAutomaticos().getSelectedValue() == null
-					&& view.getListAceptarConCambios().getSelectedValue() == null) {
+					&& view.getListAceptarConCambios().getSelectedValue() == null
+					&& view.getListAutomaticosDenegar().getSelectedValue() == null) {
 				JOptionPane.showMessageDialog(null, "No hay ningún artículo seleccionado", "Error",
 						JOptionPane.ERROR_MESSAGE);
 			} else {
@@ -302,6 +402,14 @@ public class AceptarDenegarArticuloController {
 						if (view.getListArticulos().getSelectedValue().getTitulo()
 								.equals(view.getListAceptarConCambios().getModel().getElementAt(i).getTitulo())) {
 							listModelCambios.removeElement(view.getListAceptarConCambios().getModel().getElementAt(i));
+						}
+					}
+
+					for (int i = 0; i < view.getListAutomaticosDenegar().getModel().getSize(); i++) {
+						if (view.getListArticulos().getSelectedValue().getTitulo()
+								.equals(view.getListAutomaticosDenegar().getModel().getElementAt(i).getTitulo())) {
+							listModelAutoDenegar
+									.removeElement(view.getListAutomaticosDenegar().getModel().getElementAt(i));
 						}
 					}
 
@@ -344,6 +452,15 @@ public class AceptarDenegarArticuloController {
 						}
 					}
 
+					for (int i = 0; i < view.getListAutomaticosDenegar().getModel().getSize(); i++) {
+
+						if (view.getListAutomaticos().getSelectedValue().getTitulo()
+								.equals(view.getListAutomaticosDenegar().getModel().getElementAt(i).getTitulo())) {
+							listModelAutoDenegar
+									.removeElement(view.getListAutomaticosDenegar().getModel().getElementAt(i));
+						}
+					}
+
 					listModelAuto.removeElement(view.getListAutomaticos().getSelectedValue());
 					// Si no hay elementos en las listas, se cierra la ventana
 					if (listModelAuto.isEmpty() && listModel.isEmpty() && listModelCambios.isEmpty()) {
@@ -362,7 +479,7 @@ public class AceptarDenegarArticuloController {
 						view.gettpListas().setSelectedIndex(0);
 						view.gettpListas().setEnabledAt(1, false);
 					}
-				} else {
+				} else if (view.gettpListas().getSelectedIndex() == 2) {
 					int indice = view.getListAceptarConCambios().getSelectedIndex();
 					model.actualizarDecisionFinal("Rechazado",
 							view.getListAceptarConCambios().getSelectedValue().getTitulo());
@@ -385,6 +502,15 @@ public class AceptarDenegarArticuloController {
 						}
 					}
 
+					for (int i = 0; i < view.getListAutomaticosDenegar().getModel().getSize(); i++) {
+
+						if (view.getListAceptarConCambios().getSelectedValue().getTitulo()
+								.equals(view.getListAutomaticosDenegar().getModel().getElementAt(i).getTitulo())) {
+							listModelAutoDenegar
+									.removeElement(view.getListAutomaticosDenegar().getModel().getElementAt(i));
+						}
+					}
+
 					listModelCambios.removeElement(view.getListAceptarConCambios().getSelectedValue());
 					// Si no hay elementos en las listas, se cierra la ventana
 					if (listModelAuto.isEmpty() && listModel.isEmpty() && listModelCambios.isEmpty()) {
@@ -403,14 +529,58 @@ public class AceptarDenegarArticuloController {
 						view.gettpListas().setSelectedIndex(0);
 						view.gettpListas().setEnabledAt(2, false);
 					}
-				}
-			}
 
-			if (view.getListAutomaticos().getModel().getSize() == 0) {
-				view.gettpListas().setEnabledAt(1, false);
-			}
-			if (view.getListAceptarConCambios().getModel().getSize() == 0) {
-				view.gettpListas().setEnabledAt(2, false);
+				} else {
+					int indice = view.getListAutomaticosDenegar().getSelectedIndex();
+					model.actualizarDecisionFinal("Rechazado",
+							view.getListAutomaticosDenegar().getSelectedValue().getTitulo());
+					SwingUtil.showMessage("Artículo rechazado correctamente", "Información",
+							JOptionPane.INFORMATION_MESSAGE);
+					// Si el artículo está en la otra lista, lo elimina también
+					for (int i = 0; i < view.getListArticulos().getModel().getSize(); i++) {
+
+						if (view.getListAutomaticosDenegar().getSelectedValue().getTitulo()
+								.equals(view.getListArticulos().getModel().getElementAt(i).getTitulo())) {
+							listModel.removeElement(view.getListArticulos().getModel().getElementAt(i));
+						}
+					}
+
+					for (int i = 0; i < view.getListAutomaticos().getModel().getSize(); i++) {
+
+						if (view.getListAutomaticosDenegar().getSelectedValue().getTitulo()
+								.equals(view.getListAutomaticos().getModel().getElementAt(i).getTitulo())) {
+							listModelAuto.removeElement(view.getListAutomaticos().getModel().getElementAt(i));
+						}
+					}
+
+					for (int i = 0; i < view.getListAceptarConCambios().getModel().getSize(); i++) {
+
+						if (view.getListAutomaticosDenegar().getSelectedValue().getTitulo()
+								.equals(view.getListAceptarConCambios().getModel().getElementAt(i).getTitulo())) {
+							listModelCambios.removeElement(view.getListAceptarConCambios().getModel().getElementAt(i));
+						}
+					}
+
+					listModelAutoDenegar.removeElement(view.getListAutomaticosDenegar().getSelectedValue());
+					// Si no hay elementos en las listas, se cierra la ventana
+					if (listModelAuto.isEmpty() && listModel.isEmpty() && listModelCambios.isEmpty()
+							&& listModelAutoDenegar.isEmpty()) {
+						SwingUtil.showMessage("No tienes ningún artículo pendiente de registrar", "Información",
+								JOptionPane.INFORMATION_MESSAGE);
+						view.getFrame().dispose();
+					}
+					// Cuando se elimina un elemento se va seleccionando el elemento anterior
+					// excepto si el índice es 0
+					if (indice != 0) {
+						view.getListAutomaticosDenegar().setSelectedIndex(indice - 1);
+					} else {
+						view.getListAutomaticosDenegar().setSelectedIndex(0);
+					}
+					if (view.getListAutomaticosDenegar().getModel().getSize() == 0) {
+						view.gettpListas().setSelectedIndex(0);
+						view.gettpListas().setEnabledAt(3, false);
+					}
+				}
 			}
 
 		});
@@ -428,6 +598,7 @@ public class AceptarDenegarArticuloController {
 
 				}
 				view.getbtnAceptarTodos().setEnabled(false);
+				view.getbtnDenegarTodos().setEnabled(false);
 				view.getListArticulos().setSelectedIndex(0);
 				introducirDatos();
 				view.getListAutomaticos().clearSelection();
@@ -440,14 +611,17 @@ public class AceptarDenegarArticuloController {
 
 				}
 				view.getbtnAceptarTodos().setEnabled(true);
+				view.getbtnDenegarTodos().setEnabled(false);
 				view.getListArticulos().clearSelection();
 				if (view.getListAutomaticos().getModel().getSize() > 0) {
 					view.getListAutomaticos().setSelectedIndex(0);
 					introducirDatos();
 				}
-			} else {
+			} else if (view.gettpListas().getSelectedIndex() == 2) {
 				view.getListArticulos().clearSelection();
 				view.getListAceptarConCambios().clearSelection();
+				view.getbtnAceptarTodos().setEnabled(false);
+				view.getbtnDenegarTodos().setEnabled(false);
 				if (view.getListAceptarConCambios().getModel().getSize() > 0) {
 					view.getListAceptarConCambios().setSelectedIndex(0);
 					introducirDatos();
@@ -457,6 +631,20 @@ public class AceptarDenegarArticuloController {
 				view.getContentPane().add(view.getbtnAceptarConCambios(), "cell 10 13");
 				view.getContentPane().revalidate();
 				view.getContentPane().repaint();
+			} else {
+				if (view.getbtnAceptar().getParent() == null) {
+					view.getContentPane().remove(view.getbtnAceptarConCambios());
+					view.getContentPane().add(view.getbtnAceptar(), "cell 10 13");
+					view.getContentPane().repaint();
+
+				}
+				view.getbtnAceptarTodos().setEnabled(false);
+				view.getbtnDenegarTodos().setEnabled(true);
+				view.getListArticulos().clearSelection();
+				if (view.getListAutomaticosDenegar().getModel().getSize() > 0) {
+					view.getListAutomaticosDenegar().setSelectedIndex(0);
+					introducirDatos();
+				}
 			}
 		});
 
@@ -470,6 +658,21 @@ public class AceptarDenegarArticuloController {
 						if (view.getListAutomaticos().getModel().getElementAt(i).getTitulo()
 								.equals(view.getListArticulos().getModel().getElementAt(j).getTitulo())) {
 							listModel.removeElement(view.getListArticulos().getModel().getElementAt(j));
+						}
+					}
+
+					for (int j = 0; j < view.getListAceptarConCambios().getModel().getSize(); j++) {
+						if (view.getListAutomaticos().getModel().getElementAt(i).getTitulo()
+								.equals(view.getListAceptarConCambios().getModel().getElementAt(j).getTitulo())) {
+							listModelCambios.removeElement(view.getListAceptarConCambios().getModel().getElementAt(j));
+						}
+					}
+
+					for (int j = 0; j < view.getListAutomaticosDenegar().getModel().getSize(); j++) {
+						if (view.getListAutomaticos().getModel().getElementAt(i).getTitulo()
+								.equals(view.getListAutomaticosDenegar().getModel().getElementAt(j).getTitulo())) {
+							listModelAutoDenegar
+									.removeElement(view.getListAutomaticosDenegar().getModel().getElementAt(j));
 						}
 					}
 				}
@@ -497,6 +700,77 @@ public class AceptarDenegarArticuloController {
 				JOptionPane.showMessageDialog(null, "No quedan artículos que aceptar", "Error",
 						JOptionPane.ERROR_MESSAGE);
 			}
+			if (view.getListAutomaticos().getModel().getSize() == 0) {
+				view.gettpListas().setEnabledAt(1, false);
+			}
+			if (view.getListAceptarConCambios().getModel().getSize() == 0) {
+				view.gettpListas().setEnabledAt(2, false);
+			}
+			if (view.getListAutomaticosDenegar().getModel().getSize() == 0) {
+				view.gettpListas().setEnabledAt(3, false);
+			}
+		});
+
+		view.getbtnDenegarTodos().addActionListener(e -> {
+			if (!listModelAutoDenegar.isEmpty()) {
+				for (int i = 0; i < view.getListAutomaticosDenegar().getModel().getSize(); i++) {
+					model.actualizarDecisionFinal("Rechazado",
+							view.getListAutomaticosDenegar().getModel().getElementAt(i).getTitulo());
+					// Si los artículos coinciden, los quito de la otra lista
+					for (int j = 0; j < view.getListArticulos().getModel().getSize(); j++) {
+						if (view.getListAutomaticosDenegar().getModel().getElementAt(i).getTitulo()
+								.equals(view.getListArticulos().getModel().getElementAt(j).getTitulo())) {
+							listModel.removeElement(view.getListArticulos().getModel().getElementAt(j));
+						}
+					}
+
+					for (int j = 0; j < view.getListAceptarConCambios().getModel().getSize(); j++) {
+						if (view.getListAutomaticosDenegar().getModel().getElementAt(i).getTitulo()
+								.equals(view.getListAceptarConCambios().getModel().getElementAt(j).getTitulo())) {
+							listModelCambios.removeElement(view.getListAceptarConCambios().getModel().getElementAt(j));
+						}
+					}
+
+					for (int j = 0; j < view.getListAutomaticos().getModel().getSize(); j++) {
+						if (view.getListAutomaticosDenegar().getModel().getElementAt(i).getTitulo()
+								.equals(view.getListAutomaticos().getModel().getElementAt(j).getTitulo())) {
+							listModelAuto.removeElement(view.getListAutomaticos().getModel().getElementAt(j));
+						}
+					}
+				}
+				// Si al quitar el elemento la lista de articulos sin decisión está vacía,se
+				// cierra la ventana
+				if (listModel.isEmpty()) {
+					SwingUtil.showMessage("Artículos aceptados correctamente", "Información",
+							JOptionPane.INFORMATION_MESSAGE);
+					SwingUtil.showMessage("No tienes ningún artículo pendiente de registrar", "Información",
+							JOptionPane.INFORMATION_MESSAGE);
+					view.getFrame().dispose();
+				} else {
+					// Si no, se eliminan todos los elementos y se pasa a la otra lista
+					listModelAutoDenegar.removeAllElements();
+					view.gettpListas().setSelectedIndex(0);
+					view.getListArticulos().setSelectedIndex(0);
+					SwingUtil.showMessage("Artículos aceptados correctamente", "Información",
+							JOptionPane.INFORMATION_MESSAGE);
+				}
+				if (view.getListAutomaticosDenegar().getModel().getSize() == 0) {
+					view.gettpListas().setSelectedIndex(0);
+					view.gettpListas().setEnabledAt(3, false);
+				}
+			} else {
+				JOptionPane.showMessageDialog(null, "No quedan artículos que aceptar", "Error",
+						JOptionPane.ERROR_MESSAGE);
+			}
+			if (view.getListAutomaticos().getModel().getSize() == 0) {
+				view.gettpListas().setEnabledAt(1, false);
+			}
+			if (view.getListAceptarConCambios().getModel().getSize() == 0) {
+				view.gettpListas().setEnabledAt(2, false);
+			}
+			if (view.getListAutomaticosDenegar().getModel().getSize() == 0) {
+				view.gettpListas().setEnabledAt(3, false);
+			}
 		});
 
 	}
@@ -506,6 +780,7 @@ public class AceptarDenegarArticuloController {
 		// Asignar el modelo al JList de la vista
 		view.getListArticulos().setModel(listModel);
 		view.getListAutomaticos().setModel(listModelAuto);
+		view.getListAutomaticosDenegar().setModel(listModelAutoDenegar);
 		view.getListAceptarConCambios().setModel(listModelCambios);
 
 	}
@@ -555,6 +830,35 @@ public class AceptarDenegarArticuloController {
 		for (AceptarDenegarArticuloDTO dto : listaDTO) {
 			if (valoracion(dto.getTitulo()) >= 3) {
 				listModelAuto.addElement(dto);
+			}
+		}
+
+		// Si no hay articulos asignados, mostrar un mensaje y cerrar la vista
+		if (articulos.isEmpty()) {
+			SwingUtil.showMessage("No tienes ningún artículo pendiente de registrar", "Información",
+					JOptionPane.INFORMATION_MESSAGE);
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean obtenerArticulosAutomaticosDenegar() {
+		// Llamar al backend para obtener los artículos asignados
+		articulos = model.obtenerArticulosSinDecisionFinal();
+		// Convertir cada Articulo a ArticuloDTO
+		List<AceptarDenegarArticuloDTO> listaDTO = new ArrayList<>();
+		for (AceptarDenegarArticuloDTO articulo : articulos) {
+			AceptarDenegarArticuloDTO dto = new AceptarDenegarArticuloDTO(articulo.getId(), articulo.getTitulo(),
+					articulo.getNombreFichero(), articulo.getNombre());
+			listaDTO.add(dto);
+		}
+
+		// Crear un modelo para el JList y agregar los DTOs
+		listModelAutoDenegar = new DefaultListModel<>();
+		for (AceptarDenegarArticuloDTO dto : listaDTO) {
+			if (valoracion(dto.getTitulo()) <= -2) {
+				listModelAutoDenegar.addElement(dto);
 			}
 		}
 
@@ -623,9 +927,12 @@ public class AceptarDenegarArticuloController {
 		} else if (view.gettpListas().getSelectedIndex() == 1) {
 			comentarioAutor = model.obtenerComentariosParaAutor((String) view.getcbRevisor().getSelectedItem(),
 					view.getListAutomaticos().getSelectedValue().getTitulo());
-		} else {
+		} else if (view.gettpListas().getSelectedIndex() == 2) {
 			comentarioAutor = model.obtenerComentariosParaAutor((String) view.getcbRevisor().getSelectedItem(),
 					view.getListAceptarConCambios().getSelectedValue().getTitulo());
+		} else {
+			comentarioAutor = model.obtenerComentariosParaAutor((String) view.getcbRevisor().getSelectedItem(),
+					view.getListAutomaticosDenegar().getSelectedValue().getTitulo());
 		}
 
 		if (comentarioAutor != null && !comentarioAutor.isEmpty()) {
@@ -644,10 +951,14 @@ public class AceptarDenegarArticuloController {
 			comentarioCoordinador = model.obtenerComentariosParaCoordinador(
 					(String) view.getcbRevisor().getSelectedItem(),
 					view.getListAutomaticos().getSelectedValue().getTitulo());
-		} else {
+		} else if (view.gettpListas().getSelectedIndex() == 2) {
 			comentarioCoordinador = model.obtenerComentariosParaCoordinador(
 					(String) view.getcbRevisor().getSelectedItem(),
 					view.getListAceptarConCambios().getSelectedValue().getTitulo());
+		} else {
+			comentarioCoordinador = model.obtenerComentariosParaCoordinador(
+					(String) view.getcbRevisor().getSelectedItem(),
+					view.getListAutomaticosDenegar().getSelectedValue().getTitulo());
 		}
 
 		if (comentarioCoordinador != null && !comentarioCoordinador.isEmpty()) {
@@ -665,9 +976,12 @@ public class AceptarDenegarArticuloController {
 		} else if (view.gettpListas().getSelectedIndex() == 1) {
 			nivelExperto = model.obtenerNivelExperto((String) view.getcbRevisor().getSelectedItem(),
 					view.getListAutomaticos().getSelectedValue().getTitulo());
-		} else {
+		} else if (view.gettpListas().getSelectedIndex() == 2) {
 			nivelExperto = model.obtenerNivelExperto((String) view.getcbRevisor().getSelectedItem(),
 					view.getListAceptarConCambios().getSelectedValue().getTitulo());
+		} else {
+			nivelExperto = model.obtenerNivelExperto((String) view.getcbRevisor().getSelectedItem(),
+					view.getListAutomaticosDenegar().getSelectedValue().getTitulo());
 		}
 
 		if (nivelExperto != null && !nivelExperto.isEmpty()) {
@@ -683,9 +997,12 @@ public class AceptarDenegarArticuloController {
 		} else if (view.gettpListas().getSelectedIndex() == 1) {
 			decision = model.obtenerDecisionRevisor((String) view.getcbRevisor().getSelectedItem(),
 					view.getListAutomaticos().getSelectedValue().getTitulo());
-		} else {
+		} else if (view.gettpListas().getSelectedIndex() == 2) {
 			decision = model.obtenerDecisionRevisor((String) view.getcbRevisor().getSelectedItem(),
 					view.getListAceptarConCambios().getSelectedValue().getTitulo());
+		} else {
+			decision = model.obtenerDecisionRevisor((String) view.getcbRevisor().getSelectedItem(),
+					view.getListAutomaticosDenegar().getSelectedValue().getTitulo());
 		}
 
 		if (decision != null && !decision.isEmpty()) {
@@ -708,8 +1025,11 @@ public class AceptarDenegarArticuloController {
 			valoraciones = model.obtenerTodasDecisiones(view.getListArticulos().getSelectedValue().getTitulo());
 		} else if (view.gettpListas().getSelectedIndex() == 1) {
 			valoraciones = model.obtenerTodasDecisiones(view.getListAutomaticos().getSelectedValue().getTitulo());
-		} else {
+		} else if (view.gettpListas().getSelectedIndex() == 2) {
 			valoraciones = model.obtenerTodasDecisiones(view.getListAceptarConCambios().getSelectedValue().getTitulo());
+		} else {
+			valoraciones = model
+					.obtenerTodasDecisiones(view.getListAutomaticosDenegar().getSelectedValue().getTitulo());
 		}
 
 		if (decision != null && !decision.isEmpty()) {

--- a/src/main/java/app/view/AceptarDenegarArticuloView.java
+++ b/src/main/java/app/view/AceptarDenegarArticuloView.java
@@ -21,6 +21,7 @@ import javax.swing.ListSelectionModel;
 
 public class AceptarDenegarArticuloView {
 
+	private JFrame frame;
 	private JPanel contentPane;
 	private JTextField tfNivelDeExperto;
 	private JTextField tfDecision;
@@ -33,15 +34,14 @@ public class AceptarDenegarArticuloView {
 	private JTextField tfValoracionGlobal;
 	private JButton btnAceptar;
 	private JButton btnRechazar;
-	private JButton btnAceptarConCambios;
-	private JLabel lbArticulosSinDecisionRegistrada;
-	private JList<AceptarDenegarArticuloDTO> lstArticulosSinDecisionRegistrada;
-
-	private JFrame frame;
-	private JTabbedPane tpListas;
-	private JList<AceptarDenegarArticuloDTO> lstAutomaticos;
 	private JButton btnAceptarTodos;
-
+	private JButton btnAceptarConCambios;
+	private JButton btnDenegarTodos;
+	private JLabel lbArticulosSinDecisionRegistrada;
+	private JTabbedPane tpListas;
+	private JList<AceptarDenegarArticuloDTO> lstArticulosSinDecisionRegistrada;
+	private JList<AceptarDenegarArticuloDTO> lstAutomaticos;
+	private JList<AceptarDenegarArticuloDTO> lstAutomaticosDenegar;
 	private JList<AceptarDenegarArticuloDTO> lstAceptarConCambios;
 
 	// --- NUEVO: botón para abrir discusiones ---
@@ -119,10 +119,13 @@ public class AceptarDenegarArticuloView {
 		lstArticulosSinDecisionRegistrada.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
 		lstAutomaticos = new JList();
-		tpListas.addTab("Automáticos", null, lstAutomaticos, null);
+		tpListas.addTab("Aceptar auto", null, lstAutomaticos, null);
 
 		lstAceptarConCambios = new JList<>();
 		tpListas.addTab("Aceptar con cambios", null, lstAceptarConCambios, null);
+		
+		lstAutomaticosDenegar = new JList();
+		tpListas.addTab("Denegar auto", null, lstAutomaticosDenegar, null);
 
 		tpComentariosParaCoordinadores = new JTextPane();
 		tpComentariosParaCoordinadores.setEditable(false);
@@ -133,13 +136,18 @@ public class AceptarDenegarArticuloView {
 		btnAceptarTodos.setFont(new Font("Tahoma", Font.PLAIN, 14));
 		contentPane.add(btnAceptarTodos, "cell 1 11 4 1");
 
+		btnDenegarTodos = new JButton("Denegar todos");
+		btnDenegarTodos.setEnabled(false);
+		btnDenegarTodos.setFont(new Font("Tahoma", Font.PLAIN, 14));
+		contentPane.add(btnDenegarTodos, "cell 1 11 4 1");
+		
 		lbValoraciónGlobal = new JLabel("Valoración global");
 		lbValoraciónGlobal.setFont(new Font("Tahoma", Font.PLAIN, 14));
 		contentPane.add(lbValoraciónGlobal, "cell 9 11,alignx left,aligny baseline");
 
 		btnAceptarConCambios = new JButton("Aceptar con cambios");
 		btnAceptarConCambios.setFont(new Font("Tahoma", Font.PLAIN, 14));
-		// contentPane.add(btnAceptarConCambios, "cell 10 13");
+		
 
 		tfValoracionGlobal = new JTextField();
 		tfValoracionGlobal.setEditable(false);
@@ -184,6 +192,10 @@ public class AceptarDenegarArticuloView {
 	public JList<AceptarDenegarArticuloDTO> getListAutomaticos() {
 		return this.lstAutomaticos;
 	}
+	
+	public JList<AceptarDenegarArticuloDTO> getListAutomaticosDenegar() {
+		return this.lstAutomaticosDenegar;
+	}
 
 	public JButton getbtnAceptar() {
 		return this.btnAceptar;
@@ -219,6 +231,10 @@ public class AceptarDenegarArticuloView {
 
 	public JButton getbtnAceptarTodos() {
 		return this.btnAceptarTodos;
+	}
+	
+	public JButton getbtnDenegarTodos() {
+		return this.btnDenegarTodos;
 	}
 
 	public JTabbedPane gettpListas() {


### PR DESCRIPTION
Funcionalidad terminada de la siguiente historia de usuario:
**Título:** Como coordinador quiero rechazar artículos automáticamente
**Descripción:** El coordinador visualiza una lista con los artículos que pueden denegarse automáticamente si se cumple el siguiente requisito:
    1. Artículos con una puntuación global <=2.
Cuando se deniegan los artículos, se modifica el campo decisionFinal de cada artículo de la lista a "Rechazado".