### PR TITLE
Feature: Como coordinador quiero ver las discusiones cerradas y abiertas (pudiendo cerrarlas)

### DIFF
--- a/src/main/java/app/controller/GestionarDiscusionesCoordinadorController.java
+++ b/src/main/java/app/controller/GestionarDiscusionesCoordinadorController.java
@@ -1,6 +1,5 @@
 package app.controller;
 
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,213 +33,329 @@ import giis.demo.util.SwingUtil;
  */
 public class GestionarDiscusionesCoordinadorController {
 
-	// Atributos de la clase
-	private GestionarDiscusionesCoordinadorModel model;
-	private GestionarDiscusionesCoordinadorView view;
-	private String email;
-	private DefaultListModel<ArticuloDiscusionDTO> listModel;
-	private List<ArticuloDiscusionDTO> articulosDTO;
-	private List<RevisionArticuloRevisionDTO> revisionesDTO;
-	private Map<Integer, List<RevisionArticuloRevisionDTO>> revisionesArticulos = new HashMap<>();
-	private static final Rol ROL = Rol.COORDINADOR;
+    // Atributos de la clase
+    private GestionarDiscusionesCoordinadorModel model;
+    private GestionarDiscusionesCoordinadorView view;
+    private String email;
+    private DefaultListModel<ArticuloDiscusionDTO> listModel;
+    private List<ArticuloDiscusionDTO> articulosDTO;
+    private List<RevisionArticuloRevisionDTO> revisionesDTO;
+    private Map<Integer, List<RevisionArticuloRevisionDTO>> revisionesArticulos = new HashMap<>();
+    private static final Rol ROL = Rol.COORDINADOR;
 
-	/**
-	 * Constructor del controller.
-	 *
-	 * <p>
-	 * Inicializa el controlador con el modelo, la vista y el correo del coordinador.
-	 * Llama al backend para cargar los artículos aptos para discusión y sus revisiones asociadas,
-	 * y posteriormente inicializa la vista.
-	 * </p>
-	 *
-	 * @param m     Modelo que maneja la lógica de negocio de las discusiones.
-	 * @param v     Vista que presenta la información de los artículos y revisiones.
-	 * @param email Correo electrónico del coordinador.
-	 */
-	public GestionarDiscusionesCoordinadorController(GestionarDiscusionesCoordinadorModel m,
-			GestionarDiscusionesCoordinadorView v, String email) {
-		this.model = m;
-		this.view = v;
-		this.email = email;
+    /**
+     * Constructor del controller.
+     * <p>
+     * Inicializa el controlador con el modelo, la vista y el correo del coordinador.
+     * Llama al backend para cargar los artículos aptos para discusión y sus revisiones asociadas,
+     * y posteriormente inicializa la vista.
+     * </p>
+     *
+     * @param m     Modelo que maneja la lógica de negocio de las discusiones.
+     * @param v     Vista que presenta la información de los artículos y revisiones.
+     * @param email Correo electrónico del coordinador.
+     */
+    public GestionarDiscusionesCoordinadorController(GestionarDiscusionesCoordinadorModel m,
+            GestionarDiscusionesCoordinadorView v, String email) {
+        this.model = m;
+        this.view = v;
+        this.email = email;
 
-		// Llamar al backend para cargar los artículos aptos para discusión
-		if (!obtenerArticulos()) {
-			return;
-		}
+        // Cargar artículos aptos para discusión.
+        if (!obtenerArticulos()) {
+            return;
+        }
 
-		// Llamar al backend para cargar las revisiones de los artículos cargados
-		// anteriormente
-		if (!obtenerRevisiones()) {
-			return;
-		}
+        // Cargar revisiones asociadas a los artículos.
+        if (!obtenerRevisiones()) {
+            return;
+        }
 
-		// Inicializar la vista una vez que los datos están cargados.
-		this.initView();
-	}
+        // Inicializar la vista.
+        this.initView();
+    }
 
-	/**
-	 * Inicializa el controller configurando los eventos de la vista.
-	 *
-	 * <p>
-	 * Se configuran los listeners para:
-	 * <ul>
-	 *   <li>Cerrar la ventana cuando se pulsa el botón "Cerrar".</li>
-	 *   <li>Mostrar las revisiones asociadas al seleccionar un artículo en la lista.</li>
-	 *   <li>Poner un artículo en discusión al pulsar el botón "Poner en Discusión".</li>
-	 * </ul>
-	 * </p>
-	 */
-	public void initController() {
-		// Botón de cerrar.
-		view.getBtnCerrar().addActionListener(e -> view.getFrame().dispose());
+    /**
+     * Configura los listeners de la vista.
+     * <p>
+     * Se configuran los siguientes listeners:
+     * <ul>
+     *   <li>Cerrar ventana ("Cerrar").</li>
+     *   <li>Cerrar discusión ("Cerrar Discusión").</li>
+     *   <li>Seleccionar un artículo para mostrar sus revisiones.</li>
+     *   <li>Cambiar el filtro (JComboBox).</li>
+     *   <li>Poner en discusión ("Poner en Discusión").</li>
+     * </ul>
+     * </p>
+     */
+    public void initController() {
+        // Listener para cerrar la ventana.
+        view.getBtnCerrar().addActionListener(e -> view.getFrame().dispose());
 
-		// Cuando se selecciona un artículo en la lista, mostrar las revisiones asociadas.
-		view.getListArticulos().addListSelectionListener(e -> {
+        // Listener para el botón "Cerrar Discusión".
+        view.getBtnCerrarDiscusion().addActionListener(e -> {
+            // Obtener el artículo seleccionado.
+            ArticuloDiscusionDTO articulo = view.getListArticulos().getSelectedValue();
+            if (articulo == null) {
+                SwingUtil.showMessage("No se ha seleccionado ningún artículo", "Error", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+            
+            // Marcar discusión como cerrada.
+            if (model.cerrarDiscusion(articulo.getIdArticulo())) {
+                SwingUtil.showMessage("Discusión cerrada correctamente", "Información", JOptionPane.INFORMATION_MESSAGE);
+                
+                // Actualizar listado según el filtro activo.
+                String filtroActual = (String) view.getComboFiltro().getSelectedItem();
+                List<ArticuloDiscusionDTO> listaActualizada = new ArrayList<>();
+                switch (filtroActual) {
+                    case "Cerradas":
+                        listaActualizada = model.getArticulosCerrados();
+                        break;
+                    case "Aptas para discusión":
+                        listaActualizada = model.getArticulosAptosDiscusion();
+                        break;
+                    case "Abiertas":
+                        listaActualizada = model.getDiscusionAbierta();
+                        break;
+                    case "Abiertas firmes":
+                        listaActualizada = model.getDiscusionAbiertaFirmes();
+                        break;
+                    case "Abiertas c/ deadline pasado":
+                        listaActualizada = model.getDiscusionAbiertaDeadlinePasado();
+                        break;
+                    case "Abiertas sin anotaciones":
+                        // Llamar al método correspondiente, si existe.
+                        break;
+                    default:
+                        break;
+                }
+                
+                // Crear un nuevo modelo y asignarlo al JList.
+                DefaultListModel<ArticuloDiscusionDTO> nuevoModelo = new DefaultListModel<>();
+                for (ArticuloDiscusionDTO a : listaActualizada) {
+                    nuevoModelo.addElement(a);
+                }
+                view.getListArticulos().setModel(nuevoModelo);
+                
+                // Limpiar revisiones y valoración.
+                view.clearRevisiones();
+                view.getLblValoracionGlobal().setText("");
+            } else {
+                SwingUtil.showMessage("Error al cerrar la discusión", "Error", JOptionPane.ERROR_MESSAGE);
+            }
+        });
 
-			// Obtener el DTO del artículo seleccionado.
-			ArticuloDiscusionDTO articuloSeleccionado = view.getListArticulos().getSelectedValue();
+        // Listener para la selección de un artículo en el JList.
+        view.getListArticulos().addListSelectionListener(e -> {
+            if (e.getValueIsAdjusting()) return;
+            
+            // Obtener el artículo seleccionado.
+            ArticuloDiscusionDTO articuloSeleccionado = view.getListArticulos().getSelectedValue();
+            if (articuloSeleccionado == null || articuloSeleccionado.getIdArticulo() == 0) {
+                return;
+            }
+            
+            // Limpiar el panel de revisiones.
+            view.getPanelRevisiones().removeAll();
+            
+            // Mostrar la valoración del artículo.
+            view.getLblValoracionGlobal().setText(Integer.toString(articuloSeleccionado.getValoracionGlobal()));
+            
+            // Obtener y mostrar las revisiones asociadas.
+            revisionesDTO = revisionesArticulos.get(articuloSeleccionado.getIdArticulo());
+            if (revisionesDTO != null) {
+                for (RevisionArticuloRevisionDTO r : revisionesDTO) {
+                    String decision = app.enums.DecisionRevisor.getLabelByValue(r.getDecisionRevisor());
+                    view.addRevisionCard(r.getNombre(), r.getNivelExperto(), decision, r.getComentariosParaCoordinador());
+                }
+            } else {
+                view.getPanelRevisiones().removeAll();
+                view.getPanelRevisiones().revalidate();
+                view.getPanelRevisiones().repaint();
+            }
+        });
 
-			// Verifica si el objeto o su id son nulos.
-			if (articuloSeleccionado == null || articuloSeleccionado.getIdArticulo() == 0) {
-				return;
-			}
-			// Limpiar el panel de revisiones antes de agregar las nuevas.
-			view.getPanelRevisiones().removeAll();
+        // Listener para el filtro del JComboBox.
+        view.getComboFiltro().addActionListener(e -> {
+            String selected = (String) view.getComboFiltro().getSelectedItem();
+            
+            // Limpiar revisiones y valoración.
+            view.clearRevisiones();
+            view.getLblValoracionGlobal().setText("");
+            
+            // Actualizar botones según el filtro.
+            updateButtonsState(selected);
+            
+            // Actualizar el listado según el filtro.
+            if ("Cerradas".equals(selected)) {
+                List<ArticuloDiscusionDTO> articulosCerrados = model.getArticulosCerrados();
+                DefaultListModel<ArticuloDiscusionDTO> closedModel = new DefaultListModel<>();
+                if (articulosCerrados.isEmpty()) {
+                    view.getListArticulos().setModel(closedModel);
+                    view.clearRevisiones();	          
+                } else {
+                    for (ArticuloDiscusionDTO articulo : articulosCerrados) {
+                        closedModel.addElement(articulo);
+                    }
+                    view.getListArticulos().setModel(closedModel);
+                }
+            } else if ("Aptas para discusión".equals(selected)) {
+                view.getListArticulos().setModel(listModel);
+            } else if ("Abiertas firmes".equals(selected)) {
+                List<ArticuloDiscusionDTO> articulosFirmes = model.getDiscusionAbiertaFirmes();
+                DefaultListModel<ArticuloDiscusionDTO> firmesModel = new DefaultListModel<>();
+                if (articulosFirmes.isEmpty()) {
+                    view.getListArticulos().setModel(firmesModel);
+                    view.clearRevisiones();
+                } else {
+                    for (ArticuloDiscusionDTO articulo : articulosFirmes) {
+                        firmesModel.addElement(articulo);
+                    }
+                    view.getListArticulos().setModel(firmesModel);
+                }
+            } else if ("Abiertas".equals(selected)) {
+                List<ArticuloDiscusionDTO> articulosAbiertos = model.getDiscusionAbierta();
+                DefaultListModel<ArticuloDiscusionDTO> abiertasModel = new DefaultListModel<>();
+                if (articulosAbiertos.isEmpty()) {
+                    view.getListArticulos().setModel(abiertasModel);
+                    view.clearRevisiones();
+                } else {
+                    for (ArticuloDiscusionDTO articulo : articulosAbiertos) {
+                        abiertasModel.addElement(articulo);
+                    }
+                    view.getListArticulos().setModel(abiertasModel);
+                }
+            } else if ("Abiertas c/ deadline pasado".equals(selected)) {
+                List<ArticuloDiscusionDTO> articulosDeadlinePasado = model.getDiscusionAbiertaDeadlinePasado();
+                DefaultListModel<ArticuloDiscusionDTO> deadlineModel = new DefaultListModel<>();
+                if (articulosDeadlinePasado.isEmpty()) {
+                    view.getListArticulos().setModel(deadlineModel);
+                    view.clearRevisiones();
+                } else {
+                    for (ArticuloDiscusionDTO articulo : articulosDeadlinePasado) {
+                        deadlineModel.addElement(articulo);
+                    }
+                    view.getListArticulos().setModel(deadlineModel);
+                }
+            }
+            // Se pueden agregar otras ramas para "Abiertas sin anotaciones" si se implementa.
+        });
 
-			// Mostrar la decisión final del artículo.
-			view.getLblValoracionGlobal().setText(Integer.toString(articuloSeleccionado.getValoracionGlobal()));
+        // Listener para el botón "Poner en Discusión".
+        view.getBtnPonerEnDiscusion().addActionListener(e -> {
+            // Obtener el artículo seleccionado.
+            ArticuloDiscusionDTO articulo = view.getListArticulos().getSelectedValue();
+            if (articulo == null) {
+                SwingUtil.showMessage("No se ha seleccionado ningún artículo", "Error", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+            // Llamar al backend para poner en discusión el artículo seleccionado.
+            if (model.ponerEnDiscusion(articulo.getIdArticulo())) {
+                SwingUtil.showMessage("Artículo puesto en discusión, se ha notificado a los revisores", "Información", JOptionPane.INFORMATION_MESSAGE);
+                
+                // Eliminar el artículo del modelo.
+                listModel.removeElement(articulo);
+                
+                // Limpiar valoraciones y revisiones.
+                view.getLblValoracionGlobal().setText("");
+                view.getPanelRevisiones().removeAll();
+            } else {
+                SwingUtil.showMessage("No se ha podido poner en discusión el artículo", "Error", JOptionPane.ERROR_MESSAGE);
+            }
+        });
+    }
 
-			// Guardar las revisiones asociadas al artículo seleccionado.
-			revisionesDTO = revisionesArticulos.get(articuloSeleccionado.getIdArticulo());
+    /**
+     * Inicializa la vista, haciéndola visible y estableciendo el modelo inicial del JList.
+     */
+    public void initView() {
+    	view.getFrame().setVisible(true);
+        view.getListArticulos().setModel(listModel);
 
-			String decision;
-			// Iterar sobre cada una de las revisiones del artículo seleccionado para mostrarlas.
-			for (RevisionArticuloRevisionDTO r : revisionesDTO) {
-				// Obtener la decisión del revisor usando el enum.
-				decision = app.enums.DecisionRevisor.getLabelByValue(r.getDecisionRevisor());
-				// Agregar la revisión a la vista.
-				view.addRevisionCard(r.getNombre(), r.getNivelExperto(), decision, r.getComentariosParaCoordinador());
-			}
+        // Llama al método para actualizar el estado de los botones
+        String filtroSeleccionado = (String) view.getComboFiltro().getSelectedItem();
+        updateButtonsState(filtroSeleccionado);
+    }
 
-		});
+    /**
+     * Obtiene las revisiones asociadas a los artículos aptos para discusión y las agrupa en un mapa
+     * donde la clave es el id del artículo.
+     *
+     * @return true si se obtuvieron las revisiones correctamente; false en caso contrario.
+     */
+    private boolean obtenerRevisiones() {
+        List<RevisionArticuloRevisionDTO> revisiones = model.getRevisionesArticulos();
+        for (RevisionArticuloRevisionDTO r : revisiones) {
+            if (revisionesArticulos.containsKey(r.getIdArticulo())) {
+                revisionesArticulos.get(r.getIdArticulo()).add(r);
+            } else {
+                List<RevisionArticuloRevisionDTO> lista = new ArrayList<>();
+                lista.add(r);
+                revisionesArticulos.put(r.getIdArticulo(), lista);
+            }
+        }
+        return true;
+    }
 
-		// Botón de poner en discusión.
-		view.getBtnPonerEnDiscusion().addActionListener(e -> {
-			// Obtener el artículo seleccionado.
-			ArticuloDiscusionDTO articulo = view.getListArticulos().getSelectedValue();
-			if (articulo == null) {
-				SwingUtil.showMessage("No se ha seleccionado ningún artículo", "Error", JOptionPane.ERROR_MESSAGE);
-				return;
-			}
-			// Llamar al backend para poner en discusión el artículo seleccionado.
-			if (model.ponerEnDiscusion(articulo.getIdArticulo())) {
-				SwingUtil.showMessage("Artículo puesto en discusión, se ha notificado a los revisores", "Información", JOptionPane.INFORMATION_MESSAGE);
-				
-				// Eliminar del listModel el artículo puesto en discusión.
-				listModel.removeElement(articulo);
-				
-				// Limpiar los campos de texto.
-				view.getLblValoracionGlobal().setText("");
-				view.getPanelRevisiones().removeAll();
-				
-				// Comprobar si el listModel está vacío.
-				if (listModel.isEmpty()) {
-					SwingUtil.showMessage("No hay ningún artículo apto para discusión", "Información",
-							JOptionPane.INFORMATION_MESSAGE);
-					view.getFrame().dispose();
-				}
-				
-			} else {
-				SwingUtil.showMessage("No se ha podido poner en discusión el artículo", "Error",
-						JOptionPane.ERROR_MESSAGE);
-			}
-		});
-	}
+    /**
+     * Obtiene los artículos aptos para discusión y actualiza el modelo del JList.
+     *
+     * @return true si se obtuvieron los artículos correctamente; false en caso contrario.
+     */
+    private boolean obtenerArticulos() {
+        List<ArticuloDiscusionDTO> articulos = model.getArticulosAptosDiscusion();
+        articulosDTO = new ArrayList<>();
+        for (ArticuloDiscusionDTO e : articulos) {
+            ArticuloDiscusionDTO dto = new ArticuloDiscusionDTO(e.getIdArticulo(), e.getTitulo(), e.getValoracionGlobal());
+            articulosDTO.add(dto);
+        }
+        listModel = new DefaultListModel<>();
+        for (ArticuloDiscusionDTO dto : articulosDTO) {
+            listModel.addElement(dto);
+        }
+        return true;
+    }
 
-	/**
-	 * Inicializa la vista.
-	 *
-	 * <p>
-	 * Hace visible el frame de la vista y establece el modelo de la lista con los artículos aptos para discusión.
-	 * </p>
-	 */
-	public void initView() {
-		view.getFrame().setVisible(true);
-		// Agregar los artículos al JList.
-		view.getListArticulos().setModel(listModel);
-	}
-
-	/**
-	 * Obtiene las revisiones asociadas a los artículos aptos para discusión.
-	 *
-	 * <p>
-	 * Llama al backend para obtener la lista de revisiones y las agrupa en un mapa,
-	 * utilizando el identificador del artículo como clave. Si no se encuentran revisiones,
-	 * se muestra un mensaje informativo.
-	 * </p>
-	 *
-	 * @return <code>true</code> si se obtuvieron las revisiones correctamente; <code>false</code> en caso contrario.
-	 */
-	private boolean obtenerRevisiones() {
-		// Llamar al backend para obtener las revisiones asociadas a los artículos aptos para discusión.
-		List<RevisionArticuloRevisionDTO> revisiones = model.getRevisionesArticulos();
-
-		// Si no se han encontrado revisiones, se muestra un mensaje.
-		if (revisiones.isEmpty()) {
-			SwingUtil.showMessage("No se han encontrado revisiones", "Información", JOptionPane.INFORMATION_MESSAGE);
-			return false;
-		}
-
-		// Convertir cada elemento a DTO y almacenarlos en un mapa con el idArticulo como clave.
-		for (RevisionArticuloRevisionDTO r : revisiones) {
-			if (revisionesArticulos.containsKey(r.getIdArticulo())) {
-				revisionesArticulos.get(r.getIdArticulo()).add(r);
-			} else {
-				List<RevisionArticuloRevisionDTO> lista = new ArrayList<>();
-				lista.add(r);
-				revisionesArticulos.put(r.getIdArticulo(), lista);
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Obtiene los artículos aptos para discusión.
-	 *
-	 * <p>
-	 * Llama al backend para obtener los artículos que cumplen los criterios de aptitud para discusión,
-	 * y actualiza el modelo de la lista en la vista. Si no se encuentran artículos aptos, se muestra un mensaje informativo.
-	 * </p>
-	 *
-	 * @return <code>true</code> si se obtuvieron los artículos correctamente; <code>false</code> en caso contrario.
-	 */
-	private boolean obtenerArticulos() {
-
-		// Llamar al backend para obtener los artículos aptos para discusión.
-		List<ArticuloDiscusionDTO> articulos = model.getArticulosAptosDiscusion();
-
-		// Si no hay artículos asignados, mostrar un mensaje y cerrar la vista.
-		if (articulos.isEmpty()) {
-			SwingUtil.showMessage("No hay ningún artículo apto para discusión", "Información",
-					JOptionPane.INFORMATION_MESSAGE);
-			return false;
-		}
-
-		// Convertir cada elemento a DTO y almacenarlos en una lista.
-		articulosDTO = new ArrayList<>();
-		for (ArticuloDiscusionDTO e : articulos) {
-			ArticuloDiscusionDTO dto = new ArticuloDiscusionDTO(e.getIdArticulo(), e.getTitulo(),
-					e.getValoracionGlobal());
-			articulosDTO.add(dto);
-		}
-
-		// Crear un modelo para el JList y agregar los DTOs.
-		listModel = new DefaultListModel<>();
-		for (ArticuloDiscusionDTO dto : articulosDTO) {
-			listModel.addElement(dto);
-		}
-
-		return true;
-	}
+    /**
+     * Actualiza el estado de los botones de la vista en función del filtro activo.
+     *
+     * @param filtro El filtro activo.
+     */
+    private void updateButtonsState(String filtro) {
+        view.getBtnPonerEnDiscusion().setEnabled(false);
+        view.getBtnCerrar().setEnabled(false);
+        view.getBtnAceptarArticulo().setEnabled(false);
+        view.getBtnRechazarArticulo().setEnabled(false);
+        view.getBtnRecordatorio().setEnabled(false);
+        view.getBtnCerrarDiscusion().setEnabled(false);
+        switch (filtro) {
+            case "Cerradas":
+                view.getBtnAceptarArticulo().setEnabled(true);
+                view.getBtnRechazarArticulo().setEnabled(true);
+                view.getBtnCerrar().setEnabled(true);
+                break;
+            case "Aptas para discusión":
+                view.getBtnPonerEnDiscusion().setEnabled(true);
+                view.getBtnCerrar().setEnabled(true);
+                break;
+            case "Abiertas":
+                view.getBtnCerrar().setEnabled(true);
+                break;
+            case "Abiertas firmes":
+                view.getBtnCerrarDiscusion().setEnabled(true);
+                view.getBtnCerrar().setEnabled(true);
+                break;
+            case "Abiertas c/ deadline pasado":
+                view.getBtnCerrarDiscusion().setEnabled(true);
+                view.getBtnCerrar().setEnabled(true);
+                break;
+            case "Abiertas sin anotaciones":
+                view.getBtnRecordatorio().setEnabled(true);
+                view.getBtnCerrar().setEnabled(true);
+                break;
+            default:
+                break;
+        }
+    }
 }

--- a/src/main/java/app/view/GestionarDiscusionesCoordinadorView.java
+++ b/src/main/java/app/view/GestionarDiscusionesCoordinadorView.java
@@ -6,48 +6,31 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JFrame;
-import javax.swing.JList;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSeparator;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingConstants;
+import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
 
 import app.dto.ArticuloDiscusionDTO;
 import app.enums.DecisionRevisor;
 
-import javax.swing.BorderFactory;
-
 public class GestionarDiscusionesCoordinadorView {
-	
+
 	// -----------------------------------------------------
 	// Atributos de la vista
 	// -----------------------------------------------------
-	private JFrame frame;                       // Marco principal
-
-	// Panel contenedor principal
+	private JFrame frame; // Marco principal
 	private JPanel contentPane;
-
-	// Lista de artículos controversiales
 	private JList<ArticuloDiscusionDTO> listArticulos;
-
-	// Etiqueta para mostrar la valoración global
 	private JLabel lblValoracionGlobal;
-
-	// Panel que contendrá las "tarjetas" de revisiones conflictivas
 	private JPanel panelRevisiones;
 	private JScrollPane scrollRevisiones;
-
-	// Botones
 	private JButton btnPonerEnDiscusion;
 	private JButton btnCerrar;
+	private JButton btnAceptarArticulo;
+	private JButton btnRechazarArticulo;
+	private JButton btnRecordatorio;
+	private JButton btnCerrarDiscusion;
+	private JComboBox<String> comboFiltro;
 
 	// -----------------------------------------------------
 	// Constructor
@@ -70,36 +53,57 @@ public class GestionarDiscusionesCoordinadorView {
 		contentPane.setLayout(new BorderLayout(10, 10));
 		frame.setContentPane(contentPane);
 
-		// -----------------------------------------------------
 		// Panel Izquierdo: Lista de artículos
-		// -----------------------------------------------------
-		JPanel panelArticulos = new JPanel(new BorderLayout());
+		JPanel panelArticulos = new JPanel(new BorderLayout(5, 5));
 		panelArticulos.setBorder(BorderFactory.createTitledBorder("Artículos aptos para discusión"));
+
+		comboFiltro = new JComboBox<>();
+		comboFiltro.addItem("Aptas para discusión");
+		comboFiltro.addItem("Abiertas");
+		comboFiltro.addItem("Cerradas");
+		comboFiltro.addItem("Abiertas firmes");
+		comboFiltro.addItem("Abiertas c/ deadline pasado");
+		comboFiltro.addItem("Abiertas sin anotaciones");
+		panelArticulos.add(comboFiltro, BorderLayout.NORTH);
 
 		listArticulos = new JList<>();
 		listArticulos.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-
 		JScrollPane scrollArticulos = new JScrollPane(listArticulos);
 		panelArticulos.add(scrollArticulos, BorderLayout.CENTER);
 		panelArticulos.setPreferredSize(new Dimension(250, 0));
-
 		contentPane.add(panelArticulos, BorderLayout.WEST);
 
-		// -----------------------------------------------------
 		// Panel Derecho: Detalles del artículo
-		// -----------------------------------------------------
 		JPanel panelDerecho = new JPanel(new BorderLayout(10, 10));
 		contentPane.add(panelDerecho, BorderLayout.CENTER);
 
-		// Panel superior: valoración global
-		JPanel panelSuperior = new JPanel(new FlowLayout(FlowLayout.CENTER));
-		panelSuperior.setBorder(BorderFactory.createTitledBorder("Valoración Global"));
+		// Panel superior combinado: Valoración + Botones de acción
+		JPanel panelSuperior = new JPanel(new FlowLayout(FlowLayout.CENTER, 20, 5));
 
-		lblValoracionGlobal = new JLabel("");
+		// Panel Valoración Global
+		JPanel panelValoracion = new JPanel();
+		panelValoracion.setLayout(new FlowLayout(FlowLayout.CENTER));
+		panelValoracion.setBorder(BorderFactory.createTitledBorder("Valoración Global"));
+		panelValoracion.setPreferredSize(new Dimension(200, 60));
+
+		lblValoracionGlobal = new JLabel("0");
 		lblValoracionGlobal.setFont(new Font("SansSerif", Font.BOLD, 16));
 		lblValoracionGlobal.setHorizontalAlignment(SwingConstants.CENTER);
+		panelValoracion.add(lblValoracionGlobal);
 
-		panelSuperior.add(lblValoracionGlobal);
+		// Panel de acción (aceptar/rechazar)
+		JPanel panelAccion = new JPanel();
+		panelAccion.setLayout(new FlowLayout(FlowLayout.CENTER, 10, 10));
+		panelAccion.setBorder(BorderFactory.createTitledBorder("Acción sobre el artículo"));
+		panelAccion.setPreferredSize(new Dimension(300, 60));
+
+		btnAceptarArticulo = new JButton("Aceptar artículo");
+		btnRechazarArticulo = new JButton("Rechazar artículo");
+		panelAccion.add(btnAceptarArticulo);
+		panelAccion.add(btnRechazarArticulo);
+
+		panelSuperior.add(panelValoracion);
+		panelSuperior.add(panelAccion);
 		panelDerecho.add(panelSuperior, BorderLayout.NORTH);
 
 		// Panel central: revisiones conflictivas
@@ -107,117 +111,92 @@ public class GestionarDiscusionesCoordinadorView {
 		panelRevisiones.setLayout(new BoxLayout(panelRevisiones, BoxLayout.Y_AXIS));
 
 		scrollRevisiones = new JScrollPane(panelRevisiones);
-		scrollRevisiones.setBorder(BorderFactory.createTitledBorder("Revisiones conflictivas"));
+		scrollRevisiones.setBorder(BorderFactory.createTitledBorder("Revisiones"));
 		scrollRevisiones.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
 		scrollRevisiones.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-
 		panelDerecho.add(scrollRevisiones, BorderLayout.CENTER);
 
 		// Panel inferior: botones
-		JPanel panelInferior = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-		btnPonerEnDiscusion = new JButton("Poner en Discusión");
-		panelInferior.add(btnPonerEnDiscusion);
-
+		JPanel panelInferior = new JPanel(new FlowLayout(FlowLayout.CENTER));
+		btnRecordatorio = new JButton("Enviar recordatorio");
+		btnCerrarDiscusion = new JButton("Cerrar discusión");
+		btnPonerEnDiscusion = new JButton("Poner en discusión");
 		btnCerrar = new JButton("Cerrar");
+
+		panelInferior.add(btnRecordatorio);
+		panelInferior.add(btnCerrarDiscusion);
+		panelInferior.add(btnPonerEnDiscusion);
 		panelInferior.add(btnCerrar);
-
 		panelDerecho.add(panelInferior, BorderLayout.SOUTH);
-
-		// Seleccionar el primer artículo por defecto (ejemplo)
-		if (listArticulos.getModel().getSize() > 0) {
-			listArticulos.setSelectedIndex(0);
-		}
 	}
 
 	// -----------------------------------------------------
 	// Métodos de la "lógica de UI" que el controlador puede invocar
 	// -----------------------------------------------------
 
-	/**
-	 * Muestra la ventana principal
-	 */
 	public void showWindow() {
 		this.frame.setVisible(true);
 	}
 
-	/**
-	 * Oculta o cierra la ventana
-	 */
 	public void hideWindow() {
 		this.frame.setVisible(false);
 	}
 
-	/**
-	 * Limpia el panel de revisiones
-	 */
 	public void clearRevisiones() {
 		panelRevisiones.removeAll();
 		panelRevisiones.revalidate();
 		scrollRevisiones.getVerticalScrollBar().setValue(0);
 	}
 
-	/**
-	 * Agrega una "tarjeta" de revisión al panel de revisiones.
-	 * NOTA: Se eliminó la lógica de colorear la decisión.
-	 */
 	public void addRevisionCard(String revisor, String nivel, String decision, String comentario) {
-	    JPanel tarjetaRevision = new JPanel(new BorderLayout(5, 5));
-	    tarjetaRevision.setBorder(BorderFactory.createCompoundBorder(
-	        new EmptyBorder(5, 5, 5, 5),
-	        BorderFactory.createCompoundBorder(
-	            new LineBorder(new Color(200, 200, 200), 1, true),
-	            new EmptyBorder(10, 10, 10, 10)
-	        )
-	    ));
-	    tarjetaRevision.setMaximumSize(new Dimension(Integer.MAX_VALUE, 200));
-	    tarjetaRevision.setBackground(new Color(250, 250, 250));
+		JPanel tarjetaRevision = new JPanel(new BorderLayout(5, 5));
+		tarjetaRevision.setBorder(BorderFactory.createCompoundBorder(
+				new EmptyBorder(5, 5, 5, 5),
+				BorderFactory.createCompoundBorder(
+						new LineBorder(new Color(200, 200, 200), 1, true),
+						new EmptyBorder(10, 10, 10, 10))));
+		tarjetaRevision.setMaximumSize(new Dimension(Integer.MAX_VALUE, 200));
+		tarjetaRevision.setBackground(new Color(250, 250, 250));
 
-	    // 1. Obtenemos la instancia de DecisionRevisor a partir de la etiqueta 'decision'
-	    DecisionRevisor decisionRevisor = DecisionRevisor.fromLabel(decision);
-	    
-	    // Construimos el encabezado HTML
-	    String encabezadoHtml = String.format("<html><body>"
-	        + "<b>%s</b> | <b>Nivel %s</b> | <b>%s</b>"
-	        + "</body></html>", revisor, nivel, decision);
+		DecisionRevisor decisionRevisor = DecisionRevisor.fromLabel(decision);
 
-	    JLabel lblEncabezado = new JLabel(encabezadoHtml);
-	    lblEncabezado.setFont(new Font("SansSerif", Font.PLAIN, 12));
+		String encabezadoHtml = String.format("<html><body>"
+				+ "<b>%s</b> | <b>Nivel %s</b> | <b>%s</b>"
+				+ "</body></html>", revisor, nivel, decision);
 
-	    // 2. Si el enum existe, aplicamos su color al label de encabezado
-	    if (decisionRevisor != null) {
-	        lblEncabezado.setForeground(decisionRevisor.getColor());
-	    }
+		JLabel lblEncabezado = new JLabel(encabezadoHtml);
+		lblEncabezado.setFont(new Font("SansSerif", Font.PLAIN, 12));
 
-	    JPanel panelEncabezado = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 5));
-	    panelEncabezado.setOpaque(false);
-	    panelEncabezado.add(lblEncabezado);
+		if (decisionRevisor != null) {
+			lblEncabezado.setForeground(decisionRevisor.getColor());
+		}
 
-	    tarjetaRevision.add(panelEncabezado, BorderLayout.NORTH);
+		JPanel panelEncabezado = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 5));
+		panelEncabezado.setOpaque(false);
+		panelEncabezado.add(lblEncabezado);
+		tarjetaRevision.add(panelEncabezado, BorderLayout.NORTH);
 
-	    JSeparator separador = new JSeparator();
-	    separador.setForeground(new Color(220, 220, 220));
-	    tarjetaRevision.add(separador, BorderLayout.CENTER);
+		JSeparator separador = new JSeparator();
+		separador.setForeground(new Color(220, 220, 220));
+		tarjetaRevision.add(separador, BorderLayout.CENTER);
 
-	    JPanel panelComentario = new JPanel(new BorderLayout(5, 5));
-	    panelComentario.setOpaque(false);
+		JPanel panelComentario = new JPanel(new BorderLayout(5, 5));
+		panelComentario.setOpaque(false);
 
-	    JLabel lblComentarioTitulo = new JLabel("Comentario:");
-	    lblComentarioTitulo.setFont(new Font("SansSerif", Font.BOLD, 12));
+		JLabel lblComentarioTitulo = new JLabel("Comentario:");
+		lblComentarioTitulo.setFont(new Font("SansSerif", Font.BOLD, 12));
+		JLabel lblComentarioValor = new JLabel("<html><p style='width:400px'>" + comentario + "</p></html>");
 
-	    JLabel lblComentarioValor = new JLabel("<html><p style='width:400px'>" + comentario + "</p></html>");
+		panelComentario.add(lblComentarioTitulo, BorderLayout.NORTH);
+		panelComentario.add(lblComentarioValor, BorderLayout.CENTER);
 
-	    panelComentario.add(lblComentarioTitulo, BorderLayout.NORTH);
-	    panelComentario.add(lblComentarioValor, BorderLayout.CENTER);
+		tarjetaRevision.add(panelComentario, BorderLayout.SOUTH);
+		panelRevisiones.add(tarjetaRevision);
+		panelRevisiones.add(Box.createRigidArea(new Dimension(0, 10)));
 
-	    tarjetaRevision.add(panelComentario, BorderLayout.SOUTH);
-
-	    panelRevisiones.add(tarjetaRevision);
-	    panelRevisiones.add(Box.createRigidArea(new Dimension(0, 10)));
-
-	    panelRevisiones.revalidate();
-	    scrollRevisiones.getVerticalScrollBar().setValue(0);
+		panelRevisiones.revalidate();
+		scrollRevisiones.getVerticalScrollBar().setValue(0);
 	}
-
 
 	// -----------------------------------------------------
 	// Getters y Setters para que el controlador acceda a los componentes
@@ -255,4 +234,23 @@ public class GestionarDiscusionesCoordinadorView {
 		return btnCerrar;
 	}
 
+	public JButton getBtnAceptarArticulo() {
+		return btnAceptarArticulo;
+	}
+
+	public JButton getBtnRechazarArticulo() {
+		return btnRechazarArticulo;
+	}
+
+	public JButton getBtnRecordatorio() {
+		return btnRecordatorio;
+	}
+
+	public JButton getBtnCerrarDiscusion() {
+		return btnCerrarDiscusion;
+	}
+
+	public JComboBox<String> getComboFiltro() {
+		return comboFiltro;
+	}
 }

--- a/src/main/resources/schemaConferencias.sql
+++ b/src/main/resources/schemaConferencias.sql
@@ -49,6 +49,7 @@ CREATE TABLE "Articulo" (
 CREATE TABLE "Discusion" (
 	"idDiscusion"	INTEGER NOT NULL UNIQUE,
 	"idArticulo"	INTEGER NOT NULL,
+	"isCerrada"	INTEGER NOT NULL DEFAULT 0,
 	PRIMARY KEY("idDiscusion" AUTOINCREMENT)
 );
 


### PR DESCRIPTION
Funcionalidad para la historia de usuario #29874 finalizada

Titulo: Como coordinador quiero ver las discusiones cerradas y abiertas (pudiendo cerrarlas)
Descripción: 
- De cada discusión, se muestra decisión global y las decisiones de cada revisor sobre el artículo.
- Filtro para ver solo las discusiones cerradas.
- Filtro para ver las discusiones abiertas donde todos los revisores se han mantenido firmes. En estas, el coordinador puede marcarlas como cerradas.
- Filtro para ver las discusiones abiertas cuyo deadline ha pasado. En estas, el coordinador puede marcarlas como cerradas.

![imagen](https://github.com/user-attachments/assets/4d369d0a-e64e-4007-b19f-bff849b9b720)
![imagen](https://github.com/user-attachments/assets/23926302-f804-4c84-ba68-8c859aa384f7)

