### PR TITLE
Feature: Como coordinador quiero enviar recordatorio a los revisores cuando la discusión no tenga anotaciones

### DIFF
--- a/src/main/java/app/controller/GestionarDiscusionesCoordinadorController.java
+++ b/src/main/java/app/controller/GestionarDiscusionesCoordinadorController.java
@@ -91,6 +91,11 @@ public class GestionarDiscusionesCoordinadorController {
     public void initController() {
         // Listener para cerrar la ventana.
         view.getBtnCerrar().addActionListener(e -> view.getFrame().dispose());
+        
+        // Listener para el botón "Enviar recordatorio".
+        view.getBtnRecordatorio().addActionListener(e -> {
+            SwingUtil.showMessage("Se ha enviado recordatorio a los revisores", "Información", JOptionPane.INFORMATION_MESSAGE);
+        });
 
         // Listener para el botón "Cerrar Discusión".
         view.getBtnCerrarDiscusion().addActionListener(e -> {
@@ -125,7 +130,7 @@ public class GestionarDiscusionesCoordinadorController {
                         listaActualizada = model.getDiscusionAbiertaDeadlinePasado();
                         break;
                     case "Abiertas sin anotaciones":
-                        // Llamar al método correspondiente, si existe.
+                        listaActualizada = model.getArticulosAbiertasSinAnotaciones();
                         break;
                     default:
                         break;
@@ -238,8 +243,21 @@ public class GestionarDiscusionesCoordinadorController {
                     }
                     view.getListArticulos().setModel(deadlineModel);
                 }
+            } else if ("Abiertas sin anotaciones".equals(selected)) {
+                // Se asume que en el modelo implementaste getArticulosAbiertasSinAnotaciones()
+                List<ArticuloDiscusionDTO> articulosSinAnotaciones = model.getArticulosAbiertasSinAnotaciones();
+                DefaultListModel<ArticuloDiscusionDTO> sinAnotacionesModel = new DefaultListModel<>();
+                if (articulosSinAnotaciones.isEmpty()) {
+                    view.getListArticulos().setModel(sinAnotacionesModel);
+                    view.clearRevisiones();
+                } else {
+                    for (ArticuloDiscusionDTO articulo : articulosSinAnotaciones) {
+                        sinAnotacionesModel.addElement(articulo);
+                    }
+                    view.getListArticulos().setModel(sinAnotacionesModel);
+                }
             }
-            // Se pueden agregar otras ramas para "Abiertas sin anotaciones" si se implementa.
+            
         });
 
         // Listener para el botón "Poner en Discusión".

--- a/src/main/java/app/model/GestionarDiscusionesCoordinadorModel.java
+++ b/src/main/java/app/model/GestionarDiscusionesCoordinadorModel.java
@@ -298,6 +298,24 @@ public class GestionarDiscusionesCoordinadorModel {
 	               + "  AND date(c.deadlineDiscusion) < date('now')";
 	    return db.executeQueryPojo(ArticuloDiscusionDTO.class, sql);
 	}
+	
+	/**
+	 * Obtiene una lista de artículos que tienen discusión abierta (isCerrada = 0)
+	 * y que no tienen ninguna anotación registrada.
+	 *
+	 * @return Lista de objetos {@link ArticuloDiscusionDTO} que representan los artículos sin anotaciones.
+	 */
+	public List<ArticuloDiscusionDTO> getArticulosAbiertasSinAnotaciones() {
+	    String sql = "SELECT DISTINCT a.idArticulo AS idArticulo, " +
+	                 "       a.titulo AS titulo, " +
+	                 "       a.valoracionGlobal AS valoracionGlobal " +
+	                 "FROM Articulo a " +
+	                 "JOIN Discusion d ON a.idArticulo = d.idArticulo " +
+	                 "WHERE d.isCerrada = 0 " +
+	                 "  AND NOT EXISTS (SELECT 1 FROM Anotacion an WHERE an.idDiscusion = d.idDiscusion)";
+	    return db.executeQueryPojo(ArticuloDiscusionDTO.class, sql);
+	}
+
 
 
 }


### PR DESCRIPTION
Funcionalidad de la historia #29873 terminada
Titulo: Como coordinador quiero enviar recordatorio a los revisores cuando la discusión no tenga anotaciones
Descripción:
- Filtro para mostrar las discusiones que no tienen anotaciones y estén abiertas.
- El coordinador pulsa un botón para enviar notificación a los revisores.

![image](https://github.com/user-attachments/assets/230e5d43-7945-463d-b58c-76f44de7f03a)
